### PR TITLE
cleanup remaining process at exit

### DIFF
--- a/fusuma-plugin-remap.gemspec
+++ b/fusuma-plugin-remap.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.required_ruby_version = ">= 2.5.1"
-  spec.add_dependency "fusuma", "~> 2.0"
+  spec.add_dependency "fusuma", "~> 3.0"
   spec.add_dependency "fusuma-plugin-keypress", "~> 0.5"
   spec.add_dependency "msgpack"
   spec.add_dependency "revdev"

--- a/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
@@ -9,6 +9,8 @@ module Fusuma
     module Inputs
       # Get keyboard events from remapper
       class RemapKeyboardInput < Input
+        include CustomProcess
+
         def config_param_types
           {
             keyboard_name_patterns: [Array, String],

--- a/lib/fusuma/plugin/remap/remapper.rb
+++ b/lib/fusuma/plugin/remap/remapper.rb
@@ -135,16 +135,18 @@ module Fusuma
 
         def set_trap
           @destroy = lambda do
-            begin
-              @source_keyboards.each { |kbd| kbd.ungrab }
-            rescue => e
-              puts e.message
+            @source_keyboards.each do |kbd|
+              kbd.ungrab
+            rescue Errno::EINVAL
+              # already ungrabbed
             end
+
             begin
               @uinput.destroy
-            rescue => e
-              puts e.message
+            rescue IOError
+              # already destroyed
             end
+
             exit 0
           end
 


### PR DESCRIPTION
Shutdown child process created by fork at input plugin startup
  - [x] Override Plugin::Base#shutdown with including CustomProcess
  - [x] Update gemspec to depend on fusuma 3(not released yet)

The background for this PR includes the following issues:

- When there are residual processes at startup, it can lead to a failure in starting up.
  - Some input plugins are believed to be the cause.
  - A feature to kill child processes has been added to CustomProcess#shutdown when the main process ends.
- After a kill operation, the original keyboard input remains grabbed.