### PR TITLE
Wait for device removal and reload keyboard

### DIFF
--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -303,15 +303,20 @@ module Fusuma
           # @return [Array<Revdev::EventDevice>]
           def select
             loop do
-              Fusuma::Device.reset
+              Fusuma::Device.reset # reset cache to get the latest device information
               devices = Fusuma::Device.all.select { |d| Array(@names).any? { |name| d.name =~ /#{name}/ } }
               if devices.empty?
-                sleep 3
+                wait_for_device
+
                 next
               end
 
               return devices.map { |d| Revdev::EventDevice.new("/dev/input/#{d.id}") }
             end
+          end
+
+          def wait_for_device
+            sleep 3
           end
         end
 

--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -1,0 +1,46 @@
+require "spec_helper"
+
+require "fusuma/plugin/remap/keyboard_remapper"
+require "fusuma/device"
+
+RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
+  describe "#initialize" do
+  end
+
+  describe "#run" do
+    before do
+      allow_any_instance_of(described_class).to receive(:create_virtual_keyboard)
+      allow_any_instance_of(described_class).to receive(:grab_events)
+    end
+  end
+
+  describe Fusuma::Plugin::Remap::KeyboardRemapper::KeyboardSelector do
+    describe "#select" do
+      let(:selector) { described_class.new(["dummy_valid_device"]) }
+      let(:event_device) { double(Revdev::EventDevice) }
+
+      context "with find devices" do
+        before do
+          allow(Fusuma::Device).to receive(:all).and_return([Fusuma::Device.new(name: "dummy_valid_device", id: "dummy")])
+          allow(Revdev::EventDevice).to receive(:new).and_return(event_device)
+        end
+        it "should be Array of Revdev::EventDevice" do
+          expect(selector.select).to be_a_kind_of(Array)
+          expect(selector.select.first).to eq(event_device)
+        end
+      end
+
+      context "without find device" do
+        before do
+          allow(selector).to receive(:loop).and_yield
+          allow(Fusuma::Device).to receive(:all).and_return([])
+        end
+        it "wait for device" do
+          expect(selector).to receive(:loop).and_yield
+          expect(selector).to receive(:wait_for_device)
+          selector.select
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Watch for device removal and reload the keyboard.
  - fix error that keyboard is not loaded at startup when using other virtual keyboards.
- Send current layer via the Fusuma Input plugin to identify the remapped keys.
  - Use MessagePack format to send the data.

Closes: #3 
