### PR TITLE
feat: support multiple touchpads concurrently

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,76 @@ plugin:
 This configuration allows you to specify which keys will trigger the emergency stop functionality.
 It is important to verify this keybind to ensure a swift response during unexpected situations.
 
+### Input Device Detection
+
+#### Keyboard
+
+configure `plugin.inputs.remap_keyboard_input` in `~/.config/fusuma/config.yml` to specify which physical keyboard to remap.
+
+If your external or built-in keyboard is not detected, run `libinput list-devices` to find its name and add a matching pattern under `keyboard_name_patterns`.
+
+```yaml
+plugin:
+  inputs:
+    remap_keyboard_input:
+      # By default, Fusuma will detect physical keyboards matching these patterns.
+      # You can specify multiple regular‐expression strings in an array.
+      keyboard_name_patterns:
+        # Default value
+        - keyboard|Keyboard|KEYBOARD
+
+      # Emergency stop key combination.
+      # Specify exactly two keys joined by '+'.
+      emergency_ungrab_keys: RIGHTCTRL+LEFTCTRL
+```
+
+You can customize `keyboard_name_patterns` like this:
+
+```yaml
+plugin:
+  inputs:
+    remap_keyboard_input:
+      keyboard_name_patterns:
+        - xremap                     # Virtual keyboard created by another remapper
+        - PFU Limited HHKB-Hybrid    # External keyboard
+        - keyboard|Keyboard|KEYBOARD # Default pattern
+```
+
+If your keyboard isn’t detected, run:
+
+```sh
+libinput list-devices
+```
+
+and add a suitable name pattern.
+
+#### Touchpad
+
+To specify touchpad name, configure `plugin.inputs.remap_touchpad_input`:
+
+```yaml
+plugin:
+  inputs:
+    remap_touchpad_input:
+      # By default, Fusuma will detect physical touchpads matching these patterns.
+      touchpad_name_patterns:
+        # Default values
+        - touchpad|Touchpad|TOUCHPAD
+        - trackpad|Trackpad|TRACKPAD
+```
+
+You can customize `touchpad_name_patterns` like this:
+
+```yaml
+plugin:
+  inputs:
+    remap_touchpad_input:
+      touchpad_name_patterns:
+        - Apple Inc. Magic Trackpad   # External Trackpad
+        - your touchpad device name   # Any other touchpad
+        - Touchpad|Trackpad           # match to "Touchpad" or "Trackpad"
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/iberianpig/fusuma-plugin-remap. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/lib/fusuma/plugin/inputs/remap_keyboard_input.yml
+++ b/lib/fusuma/plugin/inputs/remap_keyboard_input.yml
@@ -1,7 +1,8 @@
 plugin:
   inputs:
     remap_keyboard_input:
-      keyboard_name_patterns: ["keyboard", "Keyboard", "KEYBOARD"]
+      keyboard_name_patterns: 
+        - keyboard|Keyboard|KEYBOARD
       emergency_ungrab_keys: RIGHTCTRL+LEFTCTRL
   buffers:
     keypress_buffer:

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.yml
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.yml
@@ -1,4 +1,6 @@
 plugin:
   inputs:
     remap_touchpad_input:
-      touchpad_name_patterns: ["touchpad", "Touchpad", "TOUCHPAD"]
+      touchpad_name_patterns: 
+        - touchpad|Touchpad|TOUCHPAD
+        - trackpad|Trackpad|TRACKPAD

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -310,7 +310,7 @@ module Fusuma
 
         # Devices to detect key presses and releases
         class KeyboardSelector
-          def initialize(names = ["keyboard", "Keyboard", "KEYBOARD"])
+          def initialize(names)
             @names = names
           end
 

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -85,7 +85,8 @@ module Fusuma
               when Revdev::ABS_MT_TOOL_TYPE
                 # ignore
               else
-                raise "unhandled event"
+                # raise "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
+                MultiLogger.warn "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
               end
             when Revdev::EV_KEY
               case input_event.code
@@ -115,10 +116,10 @@ module Fusuma
               when Revdev::SYN_DROPPED
                 MultiLogger.error "Dropped: #{input_event.value}"
               else
-                raise "unhandled event", "#{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
+                raise "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
               end
             else
-              raise "unhandled event", "#{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
+              raise "unhandled event:#{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
             end
 
             # TODO:

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -78,14 +78,15 @@ module Fusuma
                 touch_state[mt_slot][:X] = input_event.value
               when Revdev::ABS_MT_POSITION_Y
                 touch_state[mt_slot][:Y] = input_event.value
-              when Revdev::ABS_X, Revdev::ABS_Y
-                # ignore
-              when Revdev::ABS_MT_PRESSURE
-                # ignore
-              when Revdev::ABS_MT_TOOL_TYPE
+              when Revdev::ABS_X, Revdev::ABS_Y,
+                Revdev::ABS_MT_PRESSURE,
+                Revdev::ABS_MT_TOOL_TYPE,
+                Revdev::ABS_MT_TOUCH_MAJOR,
+                Revdev::ABS_MT_TOUCH_MINOR,
+                Revdev::ABS_MT_ORIENTATION,
+                Revdev::ABS_PRESSURE
                 # ignore
               else
-                # raise "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
                 MultiLogger.warn "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
               end
             when Revdev::EV_KEY

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -120,7 +120,7 @@ module Fusuma
                 raise "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
               end
             else
-              raise "unhandled event:#{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
+              raise "unhandled event: #{input_event.hr_type}, #{input_event.hr_code}, #{input_event.value}"
             end
 
             # TODO:


### PR DESCRIPTION
This change updates `TouchpadRemapper` to support multiple physical touchpads.  
With this update, you can collect events from all configured touchpads simultaneously, run per-device palm detection, and forward the filtered events to Fusuma.

---

## Changes

1. Constructor parameters  
   - Renamed `source_touchpad:` to `source_touchpads:` (array)  
   - Instantiate a `PalmDetection` object for each touchpad and store them in `@palm_detectors`

2. Event loop enhancements  
   - Pass all touchpad file descriptors to `IO.select` for concurrent monitoring  
   - Identify which device generated the event and call `read_input_event` on that instance  
   - Perform palm detection via `@palm_detectors[touchpad].palm?(…)` per device

3. Virtual touchpad creation  
   - In `create_virtual_touchpad`, use the first element of `@source_touchpads` (`.first`) when creating the uinput device

---

## Verification Steps

1. Create and navigate to a working directory  
   ```bash
   mkdir /tmp/fusuma
   cd /tmp/fusuma
   ```

2. Create a `Gemfile` with the following content  
   ```ruby
   source "https://rubygems.org"

   gem "fusuma-plugin-remap", git: "git@github.com:iberianpig/fusuma-plugin-remap", branch: "fix/select-multiple-touchpads"
   gem "fusuma-plugin-thumbsense"
   ```

3. Install dependencies  
   ```bash
   bundle install
   ```

4. Run Fusuma and test with multiple touchpads  
   ```bash
   bundle exec fusuma
   ```

Verify that swipe, tap, and other gestures are detected correctly on each touchpad  
