### PR TITLE
feat: add modifier key remapping, output sequences, and layer merge support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,20 +41,83 @@ $ sudo gem install fusuma-plugin-remap
 
 ### Remap
 
-Currently, remapping is only possible in the thumbsense context.
-Please install [fusuma-plugin-thumbsense](https://github.com/iberianpig/fusuma-plugin-thumbsense)
+You can remap keys in `~/.config/fusuma/config.yml`. The `remap` section defines key remappings.
 
-First, add the 'thumbsense' context to `~/.config/fusuma/config.yml`.
-The context is separated by `---` and specified by `context: { thumbsense: true }`.
+#### Basic Remap
 
-### Example
-
-Set the following code in `~/.config/fusuma/config.yml`.
+Simple key-to-key remapping without any context:
 
 ```yaml
+remap:
+  CAPSLOCK: LEFTCTRL
+  LEFTALT: LEFTMETA
+  LEFTMETA: LEFTALT
+```
 
+#### Key Alias for Modifiers
+
+When a simple key remap is defined (e.g., `CAPSLOCK: LEFTCTRL`), the key acts as an **alias** for the target modifier. The modifier state tracks the remapped key, not the physical key.
+
+```yaml
+remap:
+  CAPSLOCK: LEFTCTRL  # CAPSLOCK acts as LEFTCTRL alias
+  LEFTCTRL+LEFTSHIFT+J: LEFTMETA+LEFTCTRL+DOWN  # Combination using the alias
+```
+
+With this configuration:
+- Physical `CAPSLOCK` is treated as `LEFTCTRL`
+- Physical `CAPSLOCK+LEFTSHIFT+J` triggers `LEFTCTRL+LEFTSHIFT+J` combination
+- This outputs `LEFTMETA+LEFTCTRL+DOWN`
+
+#### Output Sequence
+
+You can send multiple key combinations in sequence using an array:
+
+```yaml
+remap:
+  LEFTCTRL+U: [LEFTSHIFT+HOME, DELETE]  # Select to line start, then delete
+  LEFTCTRL+K: [LEFTSHIFT+END, DELETE]   # Select to line end, then delete
+```
+
+#### Modifier + Key Combinations
+
+Remap modifier key combinations to other keys or combinations:
+
+```yaml
+remap:
+  LEFTCTRL+J: DOWN
+  LEFTCTRL+K: UP
+  LEFTCTRL+H: LEFT
+  LEFTCTRL+L: RIGHT
+  LEFTALT+N: LEFTCTRL+TAB           # Next tab
+  LEFTALT+P: LEFTCTRL+LEFTSHIFT+TAB # Previous tab
+```
+
+### Context
+
+You can define different remappings for different contexts. Contexts are separated by `---`.
+
+#### Application Context
+
+Remap keys only for specific applications:
+
+```yaml
 ---
-context: 
+context:
+  application: Alacritty
+
+remap:
+  LEFTMETA+N: LEFTCTRL+LEFTSHIFT+T  # New tab in terminal
+  LEFTMETA+W: LEFTCTRL+LEFTSHIFT+W  # Close tab
+```
+
+#### Thumbsense Context
+
+For thumbsense mode, install [fusuma-plugin-thumbsense](https://github.com/iberianpig/fusuma-plugin-thumbsense):
+
+```yaml
+---
+context:
   thumbsense: true
 
 remap:
@@ -63,6 +126,35 @@ remap:
   F: BTN_LEFT
   D: BTN_RIGHT
   SPACE: BTN_LEFT
+```
+
+### Complete Example
+
+```yaml
+# Default remappings (always active)
+remap:
+  CAPSLOCK: LEFTCTRL
+  LEFTALT: LEFTMETA
+  LEFTMETA: LEFTALT
+  LEFTCTRL+J: DOWN
+  LEFTCTRL+K: UP
+
+---
+# Application-specific remappings
+context:
+  application: Alacritty
+
+remap:
+  LEFTMETA+N: LEFTCTRL+LEFTSHIFT+T
+
+---
+# Thumbsense mode
+context:
+  thumbsense: true
+
+remap:
+  J: BTN_LEFT
+  K: BTN_RIGHT
 ```
 
 ## Emergency Stop Keybind for Virtual Keyboard

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -55,7 +55,7 @@ module Fusuma
                 next
               end
 
-              next_mapping = @layer_manager.find_mapping(layer)
+              next_mapping = @layer_manager.find_merged_mapping(layer)
               next
             end
 

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -101,7 +101,7 @@ module Fusuma
               # e.g., LEFTCTRL+U: [LEFTSHIFT+HOME, DELETE]
               #      → Send Shift+Home → Send Delete
               # Like modifier remap, temporarily release original modifiers before sending
-              if is_modifier_remap && input_event.value == 1
+              if input_event.value == 1 # press only
                 execute_modifier_remap(remapped, input_event)
               end
               next

--- a/lib/fusuma/plugin/remap/layer_manager.rb
+++ b/lib/fusuma/plugin/remap/layer_manager.rb
@@ -8,6 +8,7 @@ module Fusuma
       class LayerManager
         require "singleton"
         include Singleton
+
         attr_reader :reader, :writer, :current_layer, :layers
 
         def initialize

--- a/lib/fusuma/plugin/remap/modifier_state.rb
+++ b/lib/fusuma/plugin/remap/modifier_state.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "set"
+
+module Fusuma
+  module Plugin
+    module Remap
+      # Tracks the pressed state of modifier keys
+      class ModifierState
+        MODIFIERS = Set.new(%w[
+          LEFTCTRL RIGHTCTRL
+          LEFTALT RIGHTALT
+          LEFTSHIFT RIGHTSHIFT
+          LEFTMETA RIGHTMETA
+        ]).freeze
+
+        def initialize
+          @pressed = Set.new
+        end
+
+        def update(key, event_value)
+          return unless modifier?(key)
+
+          case event_value
+          when 1 then @pressed.add(key)
+          when 0 then @pressed.delete(key)
+          end
+        end
+
+        def current_combination(key)
+          return key if modifier?(key)
+
+          modifiers = pressed_modifiers
+          if modifiers.empty?
+            key
+          else
+            "#{modifiers.join("+")}+#{key}"
+          end
+        end
+
+        def pressed_modifiers
+          @pressed.to_a.sort
+        end
+
+        def modifier?(key)
+          MODIFIERS.include?(key)
+        end
+
+        def reset
+          @pressed.clear
+        end
+      end
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/layer_manager_spec.rb
+++ b/spec/fusuma/plugin/remap/layer_manager_spec.rb
@@ -1,0 +1,255 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/layer_manager"
+require "fusuma/config"
+
+RSpec.describe Fusuma::Plugin::Remap::LayerManager do
+  let(:manager) { described_class.instance }
+
+  before do
+    # Reset singleton state for each test
+    manager.instance_variable_set(:@layers, {})
+    manager.instance_variable_set(:@merged_layers, nil)
+  end
+
+  describe "CONTEXT_PRIORITIES" do
+    it "defines thumbsense with priority 1" do
+      expect(described_class::CONTEXT_PRIORITIES[:thumbsense]).to eq(1)
+    end
+
+    it "defines application with priority 2" do
+      expect(described_class::CONTEXT_PRIORITIES[:application]).to eq(2)
+    end
+  end
+
+  describe "#find_merged_mapping" do
+    # Helper to set up config search results based on context
+    def stub_config_for_contexts(context_mappings)
+      allow(Fusuma::Config::Searcher).to receive(:with_context) do |context, &block|
+        # Find matching context
+        result = context_mappings[context]
+        if result
+          allow(Fusuma::Config).to receive(:search).and_return(result)
+        else
+          allow(Fusuma::Config).to receive(:search).and_return(nil)
+        end
+        block.call
+      end
+    end
+
+    context "with only default context" do
+      let(:default_mapping) { {"leftctrl+a" => "home", "leftctrl+e" => "end"} }
+
+      before do
+        stub_config_for_contexts({} => default_mapping)
+      end
+
+      it "returns default mapping when layer is empty" do
+        result = manager.find_merged_mapping({})
+        expect(result).to eq({:"LEFTCTRL+A" => "home", :"LEFTCTRL+E" => "end"})
+      end
+    end
+
+    context "with only thumbsense context" do
+      let(:thumbsense_mapping) { {"j" => "btn_left", "k" => "btn_right"} }
+
+      before do
+        stub_config_for_contexts({thumbsense: true} => thumbsense_mapping)
+      end
+
+      it "returns thumbsense mapping when thumbsense layer is active" do
+        result = manager.find_merged_mapping({thumbsense: true})
+        expect(result).to eq({J: "btn_left", K: "btn_right"})
+      end
+    end
+
+    context "with default + thumbsense contexts" do
+      let(:default_mapping) { {"leftctrl+a" => "home", "leftctrl+e" => "end"} }
+      let(:thumbsense_mapping) { {"j" => "btn_left"} }
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {thumbsense: true} => thumbsense_mapping
+        )
+      end
+
+      it "merges default and thumbsense mappings" do
+        result = manager.find_merged_mapping({thumbsense: true})
+        expect(result).to include(:"LEFTCTRL+A" => "home")
+        expect(result).to include(:"LEFTCTRL+E" => "end")
+        expect(result).to include(J: "btn_left")
+      end
+    end
+
+    context "with default + application contexts" do
+      let(:default_mapping) { {"leftctrl+a" => "home", "leftctrl+e" => "end"} }
+      let(:application_mapping) { {"leftctrl+a" => "leftctrl+a"} } # Override default
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {application: "Google-chrome"} => application_mapping
+        )
+      end
+
+      it "application overrides default for same key" do
+        result = manager.find_merged_mapping({application: "Google-chrome"})
+        expect(result[:"LEFTCTRL+A"]).to eq("leftctrl+a")
+        expect(result[:"LEFTCTRL+E"]).to eq("end")
+      end
+    end
+
+    context "with default + thumbsense + application contexts" do
+      let(:default_mapping) { {"leftctrl+a" => "home", "leftctrl+e" => "end"} }
+      let(:thumbsense_mapping) { {"j" => "btn_left"} }
+      let(:application_mapping) { {"leftctrl+a" => "leftctrl+a"} }
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {thumbsense: true} => thumbsense_mapping,
+          {application: "Google-chrome"} => application_mapping
+        )
+      end
+
+      it "merges all contexts with correct priority" do
+        layer = {thumbsense: true, application: "Google-chrome"}
+        result = manager.find_merged_mapping(layer)
+
+        # application (priority 2) overrides default (priority 0)
+        expect(result[:"LEFTCTRL+A"]).to eq("leftctrl+a")
+        # default is inherited
+        expect(result[:"LEFTCTRL+E"]).to eq("end")
+        # thumbsense is inherited
+        expect(result[:J]).to eq("btn_left")
+      end
+    end
+
+    context "with key override scenario" do
+      let(:default_mapping) { {"a" => "b"} }
+      let(:thumbsense_mapping) { {"a" => "c"} }
+      let(:application_mapping) { {"a" => "d"} }
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {thumbsense: true} => thumbsense_mapping,
+          {application: "Google-chrome"} => application_mapping
+        )
+      end
+
+      it "higher priority context wins for same key" do
+        layer = {thumbsense: true, application: "Google-chrome"}
+        result = manager.find_merged_mapping(layer)
+
+        # application (priority 2) wins over thumbsense (priority 1) and default (priority 0)
+        expect(result[:A]).to eq("d")
+      end
+
+      it "thumbsense wins over default when only thumbsense is active" do
+        result = manager.find_merged_mapping({thumbsense: true})
+        expect(result[:A]).to eq("c")
+      end
+    end
+
+    context "with complete match (multiple keys)" do
+      let(:default_mapping) { {"a" => "default"} }
+      let(:thumbsense_mapping) { {"a" => "thumbsense"} }
+      let(:application_mapping) { {"a" => "application"} }
+      let(:complete_mapping) { {"a" => "complete"} }
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {thumbsense: true} => thumbsense_mapping,
+          {application: "Google-chrome"} => application_mapping,
+          {thumbsense: true, application: "Google-chrome"} => complete_mapping
+        )
+      end
+
+      it "complete match has highest priority" do
+        layer = {thumbsense: true, application: "Google-chrome"}
+        result = manager.find_merged_mapping(layer)
+
+        # Complete match (priority 100) wins over everything
+        expect(result[:A]).to eq("complete")
+      end
+    end
+
+    context "with empty mapping" do
+      before do
+        stub_config_for_contexts({})
+      end
+
+      it "returns empty hash when no mappings found" do
+        result = manager.find_merged_mapping({})
+        expect(result).to eq({})
+      end
+
+      it "returns empty hash for unknown context" do
+        result = manager.find_merged_mapping({unknown: true})
+        expect(result).to eq({})
+      end
+    end
+
+    context "caching behavior" do
+      let(:default_mapping) { {"a" => "b"} }
+
+      before do
+        stub_config_for_contexts({} => default_mapping)
+      end
+
+      it "caches merged mapping for same layer" do
+        layer = {}
+        first_result = manager.find_merged_mapping(layer)
+        second_result = manager.find_merged_mapping(layer)
+
+        expect(first_result).to equal(second_result) # Same object reference
+      end
+
+      it "computes different result for different layer" do
+        result1 = manager.find_merged_mapping({})
+
+        stub_config_for_contexts({thumbsense: true} => {"j" => "btn_left"})
+        result2 = manager.find_merged_mapping({thumbsense: true})
+
+        expect(result1).not_to eq(result2)
+      end
+    end
+
+    context "with unknown context type" do
+      let(:default_mapping) { {"a" => "default"} }
+      let(:custom_mapping) { {"a" => "custom"} }
+
+      before do
+        stub_config_for_contexts(
+          {} => default_mapping,
+          {custom_context: "value"} => custom_mapping
+        )
+      end
+
+      it "uses default priority 1 for unknown context types" do
+        result = manager.find_merged_mapping({custom_context: "value"})
+        # custom_context has priority 1 (same as thumbsense default)
+        # It overrides default (priority 0)
+        expect(result[:A]).to eq("custom")
+      end
+    end
+  end
+
+  describe "#find_mapping (original method)" do
+    let(:mapping) { {"a" => "b"} }
+
+    before do
+      allow(Fusuma::Config::Searcher).to receive(:find_context).and_yield
+      allow(Fusuma::Config).to receive(:search).and_return(mapping)
+    end
+
+    it "returns mapping for exact context match" do
+      result = manager.find_mapping({thumbsense: true})
+      expect(result).to eq({A: "b"})
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/modifier_state_spec.rb
+++ b/spec/fusuma/plugin/remap/modifier_state_spec.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/modifier_state"
+
+RSpec.describe Fusuma::Plugin::Remap::ModifierState do
+  let(:state) { described_class.new }
+
+  describe "#modifier?" do
+    %w[LEFTCTRL RIGHTCTRL LEFTALT RIGHTALT LEFTSHIFT RIGHTSHIFT LEFTMETA RIGHTMETA].each do |key|
+      it "#{key} is a modifier key" do
+        expect(state.modifier?(key)).to be true
+      end
+    end
+
+    %w[A X SPACE ENTER].each do |key|
+      it "#{key} is not a modifier key" do
+        expect(state.modifier?(key)).to be false
+      end
+    end
+  end
+
+  describe "#update" do
+    context "when pressing a modifier key" do
+      it "becomes pressed state on press (value=1)" do
+        state.update("LEFTCTRL", 1)
+        expect(state.pressed_modifiers).to include("LEFTCTRL")
+      end
+
+      it "releases pressed state on release (value=0)" do
+        state.update("LEFTCTRL", 1)
+        state.update("LEFTCTRL", 0)
+        expect(state.pressed_modifiers).not_to include("LEFTCTRL")
+      end
+
+      it "does not change state on repeat (value=2)" do
+        state.update("LEFTCTRL", 1)
+        state.update("LEFTCTRL", 2)
+        expect(state.pressed_modifiers).to include("LEFTCTRL")
+      end
+    end
+
+    context "when pressing a normal key" do
+      it "does not change state" do
+        state.update("A", 1)
+        expect(state.pressed_modifiers).to be_empty
+      end
+    end
+
+    context "when pressing multiple modifier keys" do
+      it "tracks all modifier keys" do
+        state.update("LEFTCTRL", 1)
+        state.update("LEFTSHIFT", 1)
+        expect(state.pressed_modifiers).to include("LEFTCTRL", "LEFTSHIFT")
+      end
+    end
+  end
+
+  describe "#pressed_modifiers" do
+    it "is empty initially" do
+      expect(state.pressed_modifiers).to be_empty
+    end
+
+    it "returns pressed modifiers sorted alphabetically" do
+      state.update("LEFTSHIFT", 1)
+      state.update("LEFTCTRL", 1)
+      expect(state.pressed_modifiers).to eq(%w[LEFTCTRL LEFTSHIFT])
+    end
+  end
+
+  describe "#current_combination" do
+    context "when no modifier is pressed" do
+      it "returns the key as-is" do
+        expect(state.current_combination("X")).to eq("X")
+      end
+    end
+
+    context "when LEFTCTRL is pressed" do
+      before { state.update("LEFTCTRL", 1) }
+
+      it "returns LEFTCTRL+X when X is pressed" do
+        expect(state.current_combination("X")).to eq("LEFTCTRL+X")
+      end
+
+      it "returns modifier key as-is when pressed" do
+        expect(state.current_combination("LEFTCTRL")).to eq("LEFTCTRL")
+      end
+    end
+
+    context "when multiple modifiers are pressed" do
+      before do
+        state.update("LEFTSHIFT", 1)
+        state.update("LEFTCTRL", 1)
+      end
+
+      it "returns sorted modifiers + key" do
+        expect(state.current_combination("X")).to eq("LEFTCTRL+LEFTSHIFT+X")
+      end
+    end
+  end
+
+  describe "#reset" do
+    it "clears all pressed states" do
+      state.update("LEFTCTRL", 1)
+      state.update("LEFTSHIFT", 1)
+      state.reset
+      expect(state.pressed_modifiers).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Motivation
Make fusuma-plugin-remap work like xremap for keyboard remapping.

## User Benefits
- Remap keys with modifier combinations (e.g., `LEFTCTRL+A: HOME`)
- Send multiple key sequences with a single shortcut (e.g., `LEFTCTRL+U: [LEFTSHIFT+HOME, DELETE]` to select and delete a line)
- Merge mappings from multiple active contexts (default + thumbsense + application)

## Example Config

### Modifier Key Remapping
```yaml
remap:
  LEFTCTRL+A: HOME
  LEFTCTRL+E: END
  LEFTCTRL+U: [LEFTSHIFT+HOME, DELETE]  # Output sequence
```

### Layer Merge
When multiple contexts are active, all applicable mappings are merged with priority:
- Priority 0: default (no context)
- Priority 1: thumbsense
- Priority 2: application (https://github.com/iberianpig/fusuma-plugin-appmatcher/pull/18)
- Priority 100: complete match (all context keys)

```yaml
# default (always active)
remap:
  LEFTCTRL+A: HOME
  LEFTCTRL+E: END

---
context: { thumbsense: true }
remap:
  J: BTN_LEFT

---
context: { application: Google-chrome }
remap:
  LEFTCTRL+A: LEFTCTRL+A  # Override default
```

With `{ thumbsense: true, application: "Google-chrome" }`:
- `LEFTCTRL+A` → `LEFTCTRL+A` (application wins)
- `LEFTCTRL+E` → `END` (inherited from default)
- `J` → `BTN_LEFT` (inherited from thumbsense)

**Note:** To use context, you need [fusuma-plugin-thumbsense](https://github.com/iberianpig/fusuma-plugin-thumbsense) or [fusuma-plugin-appmatcher](https://github.com/iberianpig/fusuma-plugin-appmatcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)