### PR TITLE
feat: add device-specific keyboard remapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,49 @@ remap:
   SPACE: BTN_LEFT
 ```
 
+#### Device Context
+
+You can define different remappings for specific keyboard devices. The `device` pattern uses case-insensitive partial matching against the physical device name.
+
+```yaml
+---
+# HHKB-specific remappings (matches device names containing "HHKB")
+context:
+  device: HHKB
+
+remap:
+  LEFTCTRL: LEFTMETA  # Swap Ctrl to Meta on HHKB
+
+---
+# Built-in keyboard remappings (matches "AT Translated Set 2 keyboard")
+context:
+  device: AT Translated
+
+remap:
+  LEFTALT: LEFTCTRL   # Remap Alt to Ctrl on built-in keyboard
+```
+
+To find your keyboard's device name, run:
+```sh
+libinput list-devices
+```
+
+#### Combined Contexts
+
+You can combine multiple context conditions. When multiple contexts are active, mappings are merged with priority order: `device` < `thumbsense` < `application`.
+
+```yaml
+---
+# HHKB + Thumbsense mode
+context:
+  device: HHKB
+  thumbsense: true
+
+remap:
+  J: BTN_LEFT
+  K: BTN_RIGHT
+```
+
 ### Complete Example
 
 ```yaml

--- a/lib/fusuma/plugin/remap/device_matcher.rb
+++ b/lib/fusuma/plugin/remap/device_matcher.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "fusuma/config"
+
+module Fusuma
+  module Plugin
+    module Remap
+      # Matches device names against device patterns defined in config
+      class DeviceMatcher
+        def initialize
+          @patterns = nil
+        end
+
+        # Find matching device pattern for a device name
+        # @param device_name [String] physical device name (e.g., "PFU HHKB-Hybrid")
+        # @return [String, nil] matched pattern (e.g., "HHKB"), or nil if no match
+        def match(device_name)
+          return nil if device_name.nil?
+
+          patterns.find { |pattern| device_name =~ /#{pattern}/i }
+        end
+
+        private
+
+        # Collect device patterns from config (cached)
+        # @return [Array<String>] device patterns (e.g., ["HHKB", "AT Translated"])
+        def patterns
+          @patterns ||= collect_patterns
+        end
+
+        # Collect unique device patterns from all context sections in keymap
+        def collect_patterns
+          keymap = Config.instance.keymap
+          return [] unless keymap.is_a?(Array)
+
+          keymap.filter_map { |section| section.dig(:context, :device) }.uniq
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -259,13 +259,13 @@ module Fusuma
           grabbed_devices = []
           new_devices.each do |device|
             wait_release_all_keys(device)
-            begin
-              device.grab
-              MultiLogger.info "Grabbed keyboard: #{device.device_name}"
-              grabbed_devices << device
-            rescue Errno::EBUSY
-              MultiLogger.error "Failed to grab keyboard: #{device.device_name}"
-            end
+            device.grab
+            MultiLogger.info "Grabbed keyboard: #{device.device_name}"
+            grabbed_devices << device
+          rescue Errno::EBUSY
+            MultiLogger.error "Failed to grab keyboard: #{device.device_name}"
+          rescue Errno::ENODEV
+            MultiLogger.warn "Device removed during grab: #{device.device_name}"
           end
 
           return if grabbed_devices.empty?
@@ -684,7 +684,7 @@ module Fusuma
 
             devices.filter_map do |d|
               Revdev::EventDevice.new("/dev/input/#{d.id}")
-            rescue Errno::ENOENT, Errno::ENODEV => e
+            rescue Errno::ENOENT, Errno::ENODEV, Errno::EACCES => e
               MultiLogger.warn "Failed to open #{d.name} (/dev/input/#{d.id}): #{e.message}"
               nil
             end

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -49,7 +49,15 @@ module Fusuma
 
           loop do
             ios = IO.select([*@source_keyboards.map(&:file), @layer_manager.reader])
-            io = ios.first.first
+            readable_ios = ios.first
+
+            # Prioritize layer changes over keyboard events to ensure
+            # layer state is updated before processing key inputs
+            io = if readable_ios.include?(@layer_manager.reader)
+              @layer_manager.reader
+            else
+              readable_ios.first
+            end
 
             if io == @layer_manager.reader
               layer = @layer_manager.receive_layer # update @current_layer

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -187,6 +187,7 @@ module Fusuma
             write_event_with_log(remapped_event, context: "remapped from #{input_key}")
           rescue Errno::ENODEV => e # device is removed
             MultiLogger.error "Device is removed: #{e.message}"
+            @device_mappings = {} # Clear cache for new device configuration
             @source_keyboards = reload_keyboards
           end
         rescue EOFError => e # device is closed

--- a/lib/fusuma/plugin/remap/layer_manager.rb
+++ b/lib/fusuma/plugin/remap/layer_manager.rb
@@ -11,8 +11,9 @@ module Fusuma
 
         # Priority order for context types (higher number = higher priority)
         CONTEXT_PRIORITIES = {
-          thumbsense: 1,
-          application: 2
+          device: 1,
+          thumbsense: 2,
+          application: 3
         }.freeze
 
         attr_reader :reader, :writer, :current_layer, :layers

--- a/spec/fusuma/plugin/remap/device_matcher_spec.rb
+++ b/spec/fusuma/plugin/remap/device_matcher_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/device_matcher"
+require "fusuma/config"
+
+RSpec.describe Fusuma::Plugin::Remap::DeviceMatcher do
+  let(:matcher) { described_class.new }
+
+  # Stub for collecting device patterns from config
+  def stub_config_with_device_patterns(patterns)
+    keymap = patterns.map do |pattern|
+      {context: {device: pattern}, remap: {}}
+    end
+    allow(Fusuma::Config.instance).to receive(:keymap).and_return(keymap)
+  end
+
+  describe "#match" do
+    context "when device patterns exist in config" do
+      before do
+        stub_config_with_device_patterns(["HHKB", "AT Translated"])
+      end
+
+      context "when device name matches a pattern" do
+        it "returns the matched pattern" do
+          expect(matcher.match("PFU HHKB-Hybrid")).to eq("HHKB")
+        end
+
+        it "matches by partial match" do
+          expect(matcher.match("AT Translated Set 2 keyboard")).to eq("AT Translated")
+        end
+
+        it "matches case-insensitively" do
+          expect(matcher.match("pfu hhkb-hybrid")).to eq("HHKB")
+        end
+      end
+
+      context "when device name does not match any pattern" do
+        it "returns nil" do
+          expect(matcher.match("Logitech USB Keyboard")).to be_nil
+        end
+      end
+
+      context "when device name is nil" do
+        it "returns nil" do
+          expect(matcher.match(nil)).to be_nil
+        end
+      end
+    end
+
+    context "when no device patterns in config" do
+      before do
+        stub_config_with_device_patterns([])
+      end
+
+      it "returns nil" do
+        expect(matcher.match("PFU HHKB-Hybrid")).to be_nil
+      end
+    end
+
+    context "when config is nil (no config file)" do
+      before do
+        allow(Fusuma::Config.instance).to receive(:keymap).and_return(nil)
+      end
+
+      it "returns nil" do
+        expect(matcher.match("PFU HHKB-Hybrid")).to be_nil
+      end
+    end
+  end
+
+  describe "pattern caching" do
+    it "collects patterns only once" do
+      expect(Fusuma::Config.instance).to receive(:keymap)
+        .once
+        .and_return([{context: {device: "HHKB"}, remap: {}}])
+
+      matcher.match("HHKB")
+      matcher.match("HHKB")
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 require "fusuma/plugin/remap/keyboard_remapper"
 require "fusuma/plugin/remap/device_selector"
+require "fusuma/plugin/remap/device_matcher"
 require "fusuma/device"
 
 RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
@@ -619,6 +620,89 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
 
       output_key = remapped || ((effective_key != "CAPSLOCK") ? effective_key : nil)
       expect(output_key).to eq("LEFTCTRL")
+    end
+  end
+
+  describe "device-specific remapping" do
+    let(:device_matcher) { instance_double(Fusuma::Plugin::Remap::DeviceMatcher) }
+    let(:hhkb_mapping) { {LEFTCTRL: "LEFTMETA"} }
+    let(:internal_mapping) { {LEFTALT: "LEFTCTRL"} }
+    let(:default_mapping) { {CAPSLOCK: "LEFTCTRL"} }
+
+    before do
+      allow(Fusuma::Plugin::Remap::DeviceMatcher).to receive(:new).and_return(device_matcher)
+      allow(layer_manager).to receive(:find_merged_mapping).and_return({})
+    end
+
+    describe "#get_mapping_for_device" do
+      before do
+        remapper.instance_variable_set(:@device_matcher, device_matcher)
+      end
+
+      context "when device name matches a pattern" do
+        before do
+          allow(device_matcher).to receive(:match).with("PFU HHKB-Hybrid").and_return("HHKB")
+          allow(layer_manager).to receive(:find_merged_mapping)
+            .with({device: "HHKB"})
+            .and_return(hhkb_mapping)
+        end
+
+        it "returns device-specific mapping" do
+          result = remapper.send(:get_mapping_for_device, "PFU HHKB-Hybrid", {})
+          expect(result).to eq(hhkb_mapping)
+        end
+
+        it "merges layer and device info when calling LayerManager" do
+          expect(layer_manager).to receive(:find_merged_mapping)
+            .with({thumbsense: true, device: "HHKB"})
+          remapper.send(:get_mapping_for_device, "PFU HHKB-Hybrid", {thumbsense: true})
+        end
+      end
+
+      context "when device name does not match any pattern" do
+        before do
+          allow(device_matcher).to receive(:match).with("Unknown Keyboard").and_return(nil)
+          allow(layer_manager).to receive(:find_merged_mapping)
+            .with({})
+            .and_return(default_mapping)
+        end
+
+        it "returns default mapping" do
+          result = remapper.send(:get_mapping_for_device, "Unknown Keyboard", {})
+          expect(result).to eq(default_mapping)
+        end
+
+        it "calls LayerManager without device info" do
+          expect(layer_manager).to receive(:find_merged_mapping).with({})
+          remapper.send(:get_mapping_for_device, "Unknown Keyboard", {})
+        end
+      end
+
+      context "caching behavior" do
+        before do
+          allow(device_matcher).to receive(:match).with("PFU HHKB-Hybrid").and_return("HHKB")
+          allow(layer_manager).to receive(:find_merged_mapping).and_return(hhkb_mapping)
+        end
+
+        it "caches mapping for same device and layer combination" do
+          expect(layer_manager).to receive(:find_merged_mapping).once
+
+          remapper.send(:get_mapping_for_device, "PFU HHKB-Hybrid", {})
+          remapper.send(:get_mapping_for_device, "PFU HHKB-Hybrid", {})
+        end
+
+        it "fetches mapping separately for different devices" do
+          allow(device_matcher).to receive(:match).with("AT Translated").and_return("AT Translated")
+          allow(layer_manager).to receive(:find_merged_mapping)
+            .with({device: "AT Translated"})
+            .and_return(internal_mapping)
+
+          expect(layer_manager).to receive(:find_merged_mapping).twice
+
+          remapper.send(:get_mapping_for_device, "PFU HHKB-Hybrid", {})
+          remapper.send(:get_mapping_for_device, "AT Translated", {})
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Add support for device-specific remap configurations using `context: { device: "..." }`
- Different keyboards (e.g., HHKB, built-in keyboard) can now have different remap settings
- Device context integrates with existing context system (thumbsense, application)

## Changes
- **DeviceMatcher class**: Pattern matching for device names (case-insensitive, partial match)
- **CONTEXT_PRIORITIES**: Added `device: 1` (lowest priority, overridden by thumbsense/application)
- **KeyboardRemapper**: Added `get_mapping_for_device` method with caching
- **README**: Added documentation for device context

## Example Configuration
```yaml
---
context:
  device: "HHKB"

remap:
  LEFTALT: LEFTMETA
  LEFTMETA: LEFTALT

---
context:
  device: 'AT Translated Set 2 keyboard'

remap:
  # us_layout_for_jp_keyboard
  YEN: BACKSLASH
  CAPSLOCK: LEFTCTRL
  MUHENKAN: LEFTALT
  HENKAN: LEFTSHIFT

---
# Combined contexts
context:
  device: HHKB
  thumbsense: true
remap:
  J: BTN_LEFT
```

## Test plan
- [x] Unit tests for DeviceMatcher (8 examples)
- [x] Unit tests for LayerManager device context (21 examples)
- [x] Unit tests for KeyboardRemapper get_mapping_for_device (7 examples)
- [x] All tests pass (140 examples, 0 failures)
- [x] Manual test with HHKB and built-in keyboard

🤖 Generated with [Claude Code](https://claude.ai/code)