### PR TITLE
fix: pass through non-keyboard events to prevent TrackPoint issues

### DIFF
--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -712,6 +712,30 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
     end
   end
 
+  describe "non-EV_KEY event passthrough" do
+    # Non-keyboard events (EV_REL, EV_ABS, etc.) should be passed through without remapping
+    # This prevents event code collision issues (e.g., KEY_ESC=1 vs REL_Y=1)
+
+    # Linux input event type constants
+    let(:ev_key) { 1 }  # EV_KEY (keyboard/button events)
+    let(:ev_rel) { 2 }  # EV_REL (relative movement: mouse, TrackPoint)
+    let(:ev_abs) { 3 }  # EV_ABS (absolute position: touchpad)
+
+    describe "#should_skip_non_key_event?" do
+      it "returns false for EV_KEY events" do
+        expect(remapper.send(:should_skip_non_key_event?, ev_key)).to be false
+      end
+
+      it "returns true for EV_REL events (mouse/trackpoint movement)" do
+        expect(remapper.send(:should_skip_non_key_event?, ev_rel)).to be true
+      end
+
+      it "returns true for EV_ABS events (touchpad absolute position)" do
+        expect(remapper.send(:should_skip_non_key_event?, ev_abs)).to be true
+      end
+    end
+  end
+
   describe "#apply_simple_remap" do
     before do
       remapper.instance_variable_set(:@modifier_state, Fusuma::Plugin::Remap::ModifierState.new)


### PR DESCRIPTION
## Summary

- Fix TrackPoint (pointing stick) vertical movement being broken when `ESC: GRAVE` remap is configured
- Skip remap processing for non-EV_KEY events (EV_REL, EV_ABS, etc.) and pass them through as-is
- Prevent event code collision issues (e.g., KEY_ESC=1 vs REL_Y=1)

## Problem

When `remap: ESC: GRAVE` is set, the TrackPoint can only move horizontally.

**Root Cause**: Event code collision
- `KEY_ESC = 1`
- `REL_Y = 1` (TrackPoint vertical movement)

The keyboard remapper was processing all event types, not just EV_KEY. This caused EV_REL events with code=1 (REL_Y) to be misidentified as ESC key presses and remapped to GRAVE.

## Solution

Skip remap processing for non-keyboard events early in the run loop:

```ruby
if should_skip_non_key_event?(input_event.type)
  write_event_with_log(input_event, context: "passthrough (non-key event)")
  next
end
```

## Test plan

- [x] All existing tests pass (81 examples, 0 failures)
- [x] New tests added for `#should_skip_non_key_event?`
- [x] Manual test: Verify TrackPoint works correctly with `ESC: GRAVE` setting
- [x] Manual test: Verify key remapping still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)