### PR TITLE
fix: use DeviceSelector in exe files to resolve NameError

### DIFF
--- a/exe/fusuma-remap
+++ b/exe/fusuma-remap
@@ -6,10 +6,16 @@ require_relative "../lib/fusuma/plugin/inputs/remap_keyboard_input"
 require_relative "../lib/fusuma/plugin/remap/version"
 require_relative "../lib/fusuma/plugin/remap/keyboard_remapper"
 require_relative "../lib/fusuma/plugin/remap/layer_manager"
+require_relative "../lib/fusuma/plugin/remap/device_selector"
 require "fusuma/config"
 require "fusuma/multi_logger"
 require "msgpack"
 require "irb"
+
+if ARGV.include?("--version") || ARGV.include?("-v")
+  puts "fusuma-remap #{Fusuma::Plugin::Remap::VERSION}"
+  exit 0
+end
 
 Fusuma::MultiLogger.instance.debug_mode = true
 Fusuma::Config.instance.custom_path = "~/.config/fusuma/config.yml"
@@ -23,8 +29,8 @@ end
 keyboard_name_pattern ||= ARGV.shift || ["keyboard", "Keyboard", "KEYBOARD"]
 touchpad_name_pattern ||= ARGV.shift || ["touchpad", "Touchpad", "TOUCHPAD"]
 
-source_keyboards = Fusuma::Plugin::Inputs::RemapKeyboardInput::KeyboardSelector.new(keyboard_name_pattern).select
-internal_touchpad = Fusuma::Plugin::Inputs::RemapKeyboardInput::TouchpadSelector.new(touchpad_name_pattern).select.first
+source_keyboards = Fusuma::Plugin::Remap::DeviceSelector.new(name_patterns: keyboard_name_pattern, device_type: :keyboard).select(wait: true)
+internal_touchpad = Fusuma::Plugin::Remap::DeviceSelector.new(name_patterns: touchpad_name_pattern, device_type: :touchpad).select(wait: true).first
 
 if source_keyboards.empty?
   warn "no keyboard found"

--- a/exe/fusuma-touchpad-remap
+++ b/exe/fusuma-touchpad-remap
@@ -6,11 +6,17 @@ require_relative "../lib/fusuma/plugin/inputs/remap_touchpad_input"
 require_relative "../lib/fusuma/plugin/remap/version"
 require_relative "../lib/fusuma/plugin/remap/touchpad_remapper"
 require_relative "../lib/fusuma/plugin/remap/layer_manager"
+require_relative "../lib/fusuma/plugin/remap/device_selector"
 require "fusuma/config"
 require "fusuma/multi_logger"
 require "revdev"
 require "msgpack"
 require "irb"
+
+if ARGV.include?("--version") || ARGV.include?("-v")
+  puts "fusuma-touchpad-remap #{Fusuma::Plugin::Remap::VERSION}"
+  exit 0
+end
 
 Fusuma::MultiLogger.instance.debug_mode = true
 Fusuma::Config.instance.custom_path = "~/.config/fusuma/config.yml"
@@ -19,7 +25,7 @@ touchpad_name_pattern = ["touchpad", "Touchpad", "TOUCHPAD"]
 
 # $DEBUG=true # puts events
 
-internal_touchpad = Fusuma::Plugin::Inputs::RemapKeyboardInput::TouchpadSelector.new(touchpad_name_pattern).select.first
+internal_touchpad = Fusuma::Plugin::Remap::DeviceSelector.new(name_patterns: touchpad_name_pattern, device_type: :touchpad).select(wait: true).first
 
 if internal_touchpad.nil?
   warn "no touchpad found"

--- a/spec/fusuma/plugin/remap/exe_smoke_spec.rb
+++ b/spec/fusuma/plugin/remap/exe_smoke_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe "Executable smoke tests" do
+  describe "fusuma-remap" do
+    it "prints version with --version flag" do
+      output = `bundle exec ruby exe/fusuma-remap --version 2>&1`
+      expect($?.success?).to be true
+      expect(output.strip).to match(/\Afusuma-remap \d+\.\d+\.\d+\z/)
+    end
+  end
+
+  describe "fusuma-touchpad-remap" do
+    it "prints version with --version flag" do
+      output = `bundle exec ruby exe/fusuma-touchpad-remap --version 2>&1`
+      expect($?.success?).to be true
+      expect(output.strip).to match(/\Afusuma-touchpad-remap \d+\.\d+\.\d+\z/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Replace removed `KeyboardSelector`/`TouchpadSelector` with `DeviceSelector` in `exe/fusuma-remap` and `exe/fusuma-touchpad-remap` to fix NameError
- Add `--version` / `-v` flag to both exe files
- Add CLI smoke tests

## Test plan
- [x] Verify version flag works via `bundle exec rspec spec/fusuma/plugin/remap/exe_smoke_spec.rb`
- [x] Verify `fusuma-remap --version` displays the correct version
- [x] Verify `fusuma-touchpad-remap --version` displays the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)