### PR TITLE
feat: remap keys to POINTER_SCROLL in thumbsense context

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ remap:
   S: POINTER_SCROLL_FINGER
 ```
 
-With this configuration, holding <kbd>S</kbd> while touching the touchpad makes one-finger movement scroll instead of moving the pointer. Releasing <kbd>S</kbd> or ending the touch returns the touchpad to normal behavior.
+With this configuration, holding <kbd>S</kbd> while touching the touchpad makes one-finger movement scroll instead of moving the pointer. Releasing <kbd>S</kbd> returns the touchpad to normal pointer movement. While <kbd>S</kbd> is held, lifting your finger and touching the touchpad again continues scrolling on the next movement.
 
 #### Device Context
 

--- a/README.md
+++ b/README.md
@@ -128,6 +128,21 @@ remap:
   SPACE: BTN_LEFT
 ```
 
+#### Pointer Scroll in Thumbsense Context
+
+`POINTER_SCROLL_FINGER` converts one-finger touchpad motion into native finger scrolling while the remapped key is held in thumbsense context. The key press is swallowed, so it does not type the original character.
+
+```yaml
+---
+context:
+  thumbsense: true
+
+remap:
+  S: POINTER_SCROLL_FINGER
+```
+
+With this configuration, holding <kbd>S</kbd> while touching the touchpad makes one-finger movement scroll instead of moving the pointer. Releasing <kbd>S</kbd> or ending the touch returns the touchpad to normal behavior.
+
 #### Device Context
 
 You can define different remappings for specific keyboard devices. The `device` pattern uses case-insensitive partial matching against the physical device name.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ remap:
 
 #### Pointer Scroll in Thumbsense Context
 
-`POINTER_SCROLL_FINGER` converts one-finger touchpad motion into native finger scrolling while the remapped key is held in thumbsense context. The key press is swallowed, so it does not type the original character.
+`POINTER_SCROLL` converts one-finger touchpad motion into native finger scrolling while the remapped key is held in thumbsense context. The key press is swallowed, so it does not type the original character.
 
 ```yaml
 ---
@@ -138,7 +138,7 @@ context:
   thumbsense: true
 
 remap:
-  S: POINTER_SCROLL_FINGER
+  S: POINTER_SCROLL
 ```
 
 With this configuration, holding <kbd>S</kbd> while touching the touchpad makes one-finger movement scroll instead of moving the pointer. Releasing <kbd>S</kbd> returns the touchpad to normal pointer movement. While <kbd>S</kbd> is held, lifting your finger and touching the touchpad again continues scrolling on the next movement.

--- a/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
@@ -3,6 +3,7 @@
 require "json"
 require_relative "../remap/keyboard_remapper"
 require_relative "../remap/layer_manager"
+require_relative "../remap/scroll_channel"
 
 module Fusuma
   module Plugin
@@ -54,6 +55,7 @@ module Fusuma
           }
 
           layer_manager = Remap::LayerManager.instance
+          scroll_channel = Remap::ScrollChannel.instance
 
           # physical keyboard input event
           @fusuma_reader, fusuma_writer = IO.pipe
@@ -64,7 +66,8 @@ module Fusuma
             remapper = Remap::KeyboardRemapper.new(
               layer_manager: layer_manager,
               fusuma_writer: fusuma_writer,
-              config: config
+              config: config,
+              scroll_channel: scroll_channel
             )
             remapper.run
           end

--- a/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_keyboard_input.rb
@@ -62,6 +62,7 @@ module Fusuma
 
           fork do
             layer_manager.writer.close
+            scroll_channel.reader.close
             @fusuma_reader.close
             remapper = Remap::KeyboardRemapper.new(
               layer_manager: layer_manager,

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
@@ -12,8 +12,6 @@ module Fusuma
       class RemapTouchpadInput < Input
         include CustomProcess
 
-        POINTER_SCROLL = "POINTER_SCROLL"
-
         def config_param_types
           {
             touchpad_name_patterns: [Array, String]
@@ -104,10 +102,8 @@ module Fusuma
             value.values.any? { |nested| contains_pointer_scroll?(nested) }
           when Array
             value.any? { |nested| contains_pointer_scroll?(nested) }
-          when String, Symbol
-            value.to_s.upcase == POINTER_SCROLL
           else
-            false
+            Remap::ScrollChannel.pointer_scroll_value?(value)
           end
         end
       end

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
@@ -62,6 +62,7 @@ module Fusuma
 
           fork do
             # layer_manager.writer.close
+            scroll_channel.writer.close
             @fusuma_reader.close
 
             # DeviceSelector waits until touchpad is found (like KeyboardSelector)

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
@@ -3,6 +3,7 @@
 require "json"
 require_relative "../remap/touchpad_remapper"
 require_relative "../remap/device_selector"
+require_relative "../remap/scroll_channel"
 
 module Fusuma
   module Plugin
@@ -10,6 +11,8 @@ module Fusuma
       # Get touchpad events from remapper
       class RemapTouchpadInput < Input
         include CustomProcess
+
+        POINTER_SCROLL_FINGER = "POINTER_SCROLL_FINGER"
 
         def config_param_types
           {
@@ -50,7 +53,8 @@ module Fusuma
         private
 
         def setup_remapper
-          # layer_manager = Remap::LayerManager.instance
+          scroll_channel = Remap::ScrollChannel.instance
+          pointer_scroll_enabled = pointer_scroll_finger_configured?
 
           # physical touchpad input event
           @fusuma_reader, fusuma_writer = IO.pipe
@@ -71,15 +75,38 @@ module Fusuma
             MultiLogger.info("touchpad: #{source_touchpads}")
 
             remapper = Remap::TouchpadRemapper.new(
-              # layer_manager: layer_manager,
               fusuma_writer: fusuma_writer,
               source_touchpads: source_touchpads,
-              touchpad_name_patterns: touchpad_name_patterns
+              touchpad_name_patterns: touchpad_name_patterns,
+              pointer_scroll_enabled: pointer_scroll_enabled,
+              scroll_channel: scroll_channel
             )
             remapper.run
           end
-          # layer_manager.reader.close
           fusuma_writer.close
+        end
+
+        def pointer_scroll_finger_configured?
+          keymap = Fusuma::Config.instance.keymap
+          Array(keymap).any? do |section|
+            remap = section[:remap] || section["remap"]
+            contains_pointer_scroll_finger?(remap)
+          end
+        rescue
+          false
+        end
+
+        def contains_pointer_scroll_finger?(value)
+          case value
+          when Hash
+            value.values.any? { |nested| contains_pointer_scroll_finger?(nested) }
+          when Array
+            value.any? { |nested| contains_pointer_scroll_finger?(nested) }
+          when String, Symbol
+            value.to_s.upcase == POINTER_SCROLL_FINGER
+          else
+            false
+          end
         end
       end
     end

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
@@ -12,7 +12,7 @@ module Fusuma
       class RemapTouchpadInput < Input
         include CustomProcess
 
-        POINTER_SCROLL_FINGER = "POINTER_SCROLL_FINGER"
+        POINTER_SCROLL = "POINTER_SCROLL"
 
         def config_param_types
           {
@@ -54,7 +54,7 @@ module Fusuma
 
         def setup_remapper
           scroll_channel = Remap::ScrollChannel.instance
-          pointer_scroll_enabled = pointer_scroll_finger_configured?
+          pointer_scroll_enabled = pointer_scroll_configured?
 
           # physical touchpad input event
           @fusuma_reader, fusuma_writer = IO.pipe
@@ -86,24 +86,24 @@ module Fusuma
           fusuma_writer.close
         end
 
-        def pointer_scroll_finger_configured?
+        def pointer_scroll_configured?
           keymap = Fusuma::Config.instance.keymap
           Array(keymap).any? do |section|
             remap = section[:remap] || section["remap"]
-            contains_pointer_scroll_finger?(remap)
+            contains_pointer_scroll?(remap)
           end
         rescue
           false
         end
 
-        def contains_pointer_scroll_finger?(value)
+        def contains_pointer_scroll?(value)
           case value
           when Hash
-            value.values.any? { |nested| contains_pointer_scroll_finger?(nested) }
+            value.values.any? { |nested| contains_pointer_scroll?(nested) }
           when Array
-            value.any? { |nested| contains_pointer_scroll_finger?(nested) }
+            value.any? { |nested| contains_pointer_scroll?(nested) }
           when String, Symbol
-            value.to_s.upcase == POINTER_SCROLL_FINGER
+            value.to_s.upcase == POINTER_SCROLL
           else
             false
           end

--- a/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
+++ b/lib/fusuma/plugin/inputs/remap_touchpad_input.rb
@@ -93,7 +93,8 @@ module Fusuma
             remap = section[:remap] || section["remap"]
             contains_pointer_scroll?(remap)
           end
-        rescue
+        rescue => e
+          MultiLogger.warn("Failed to detect POINTER_SCROLL config: #{e.message}")
           false
         end
 

--- a/lib/fusuma/plugin/remap/device_selector.rb
+++ b/lib/fusuma/plugin/remap/device_selector.rb
@@ -10,9 +10,13 @@ module Fusuma
       # Unifies TouchpadSelector implementations across the codebase
       class DeviceSelector
         POLL_INTERVAL = 3 # seconds
+        # Single source of truth for virtual device names; the remappers and the
+        # self-exclusion filter below must always agree on these
+        VIRTUAL_TOUCHPAD_NAME = "fusuma_virtual_touchpad"
+        VIRTUAL_KEYBOARD_NAME = "fusuma_virtual_keyboard"
         VIRTUAL_DEVICE_NAMES = [
-          "fusuma_virtual_touchpad",
-          "fusuma_virtual_keyboard"
+          VIRTUAL_TOUCHPAD_NAME,
+          VIRTUAL_KEYBOARD_NAME
         ].freeze
 
         # @param name_patterns [Array, String, nil] patterns for device names

--- a/lib/fusuma/plugin/remap/device_selector.rb
+++ b/lib/fusuma/plugin/remap/device_selector.rb
@@ -10,6 +10,10 @@ module Fusuma
       # Unifies TouchpadSelector implementations across the codebase
       class DeviceSelector
         POLL_INTERVAL = 3 # seconds
+        VIRTUAL_DEVICE_NAMES = [
+          "fusuma_virtual_touchpad",
+          "fusuma_virtual_keyboard"
+        ].freeze
 
         # @param name_patterns [Array, String, nil] patterns for device names
         # @param device_type [Symbol] :touchpad or :keyboard (for logging)
@@ -37,7 +41,7 @@ module Fusuma
         private
 
         def find_devices
-          if @name_patterns
+          devices = if @name_patterns
             Fusuma::Device.all.select { |d|
               Array(@name_patterns).any? { |name| d.name =~ /#{name}/ }
             }
@@ -45,6 +49,12 @@ module Fusuma
             # available returns only touchpad devices
             Fusuma::Device.available
           end
+
+          devices.reject { |device| virtual_device?(device) }
+        end
+
+        def virtual_device?(device)
+          VIRTUAL_DEVICE_NAMES.include?(device.name)
         end
 
         def to_event_devices(devices)

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -18,7 +18,7 @@ module Fusuma
         VIRTUAL_KEYBOARD_NAME = "fusuma_virtual_keyboard"
         DEFAULT_EMERGENCY_KEYBIND = "RIGHTCTRL+LEFTCTRL".freeze
         DEVICE_CHECK_INTERVAL = 3 # seconds - interval for checking new devices
-        POINTER_SCROLL_FINGER = "POINTER_SCROLL_FINGER".freeze
+        POINTER_SCROLL = "POINTER_SCROLL".freeze
 
         # Key conversion tables for better performance and readability
         KEYMAP = Revdev.constants.select { |c| c.start_with?("KEY_", "BTN_") }
@@ -321,8 +321,8 @@ module Fusuma
           @scroll_pressed_codes ||= Set.new
         end
 
-        def pointer_scroll_finger_remap?(remapped)
-          remapped.to_s.upcase == POINTER_SCROLL_FINGER
+        def pointer_scroll_remap?(remapped)
+          remapped.to_s.upcase == POINTER_SCROLL
         end
 
         def handle_pressed_pointer_scroll_key(input_event)
@@ -344,7 +344,7 @@ module Fusuma
         def handle_pointer_scroll_press(input_event, remapped)
           return false unless input_event.type == EV_KEY
           return false unless input_event.value == 1
-          return false unless pointer_scroll_finger_remap?(remapped)
+          return false unless pointer_scroll_remap?(remapped)
 
           scroll_pressed_codes.add(input_event.code)
           @scroll_channel.send_scroll(true)
@@ -615,7 +615,7 @@ module Fusuma
 
             if key_str.include?("+")
               combo_remap[key] = value
-            elsif value.is_a?(Array) || value.is_a?(Hash) || value_str&.include?("+") || pointer_scroll_finger_remap?(value)
+            elsif value.is_a?(Array) || value.is_a?(Hash) || value_str&.include?("+") || pointer_scroll_remap?(value)
               combo_remap[key] = value
             else
               simple_remap[key] = value

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -15,10 +15,10 @@ module Fusuma
       class KeyboardRemapper
         include Revdev
 
-        VIRTUAL_KEYBOARD_NAME = "fusuma_virtual_keyboard"
+        VIRTUAL_KEYBOARD_NAME = DeviceSelector::VIRTUAL_KEYBOARD_NAME
         DEFAULT_EMERGENCY_KEYBIND = "RIGHTCTRL+LEFTCTRL".freeze
         DEVICE_CHECK_INTERVAL = 3 # seconds - interval for checking new devices
-        POINTER_SCROLL = "POINTER_SCROLL".freeze
+        POINTER_SCROLL = ScrollChannel::POINTER_SCROLL
 
         # Key conversion tables for better performance and readability
         KEYMAP = Revdev.constants.select { |c| c.start_with?("KEY_", "BTN_") }
@@ -173,10 +173,7 @@ module Fusuma
                   write_event_with_log(input_event, context: "simple remap failed")
                 end
               else
-                # Passthrough: record key code to ensure press/release consistency
-                output_code = get_or_record_key_code(input_event.code, input_event.code, input_event.value)
-                passthrough_event = InputEvent.new(nil, input_event.type, output_code, input_event.value)
-                write_event_with_log(passthrough_event, context: "passthrough")
+                write_passthrough_event(input_event)
               end
               next
             else
@@ -324,7 +321,7 @@ module Fusuma
         end
 
         def pointer_scroll_remap?(remapped)
-          remapped.to_s.upcase == POINTER_SCROLL
+          ScrollChannel.pointer_scroll_value?(remapped)
         end
 
         def handle_pressed_pointer_scroll_key(input_event)
@@ -357,12 +354,18 @@ module Fusuma
           return false unless input_event.type == EV_KEY
           return false if input_event.value == 1
           return false unless pointer_scroll_remap?(remapped)
-          return false if scroll_pressed_codes.include?(input_event.code)
 
+          # Reaching here means the press was not swallowed (the key went down
+          # before the layer changed), so pass the release/repeat through as-is
+          write_passthrough_event(input_event)
+          true
+        end
+
+        # Passthrough: record key code to ensure press/release consistency
+        def write_passthrough_event(input_event)
           output_code = get_or_record_key_code(input_event.code, input_event.code, input_event.value)
           passthrough_event = InputEvent.new(nil, input_event.type, output_code, input_event.value)
           write_event_with_log(passthrough_event, context: "passthrough")
-          true
         end
 
         def reset_scroll_keys_after_device_removed

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -185,6 +185,7 @@ module Fusuma
             end
 
             next if handle_pointer_scroll_press(input_event, remapped)
+            next if handle_pointer_scroll_passthrough(input_event, remapped)
 
             # For modifier remaps, handle specially:
             # Release currently pressed modifiers → Send remapped key → Re-press modifiers
@@ -227,6 +228,7 @@ module Fusuma
             @separated_mappings_cache = {}
             @pressed_key_codes = {}
             @pressed_key_names = {}
+            reset_scroll_keys_after_device_removed
             @source_keyboards = reload_keyboards
           end
         rescue EOFError => e # device is closed
@@ -349,6 +351,25 @@ module Fusuma
           scroll_pressed_codes.add(input_event.code)
           @scroll_channel.send_scroll(true)
           true
+        end
+
+        def handle_pointer_scroll_passthrough(input_event, remapped)
+          return false unless input_event.type == EV_KEY
+          return false if input_event.value == 1
+          return false unless pointer_scroll_remap?(remapped)
+          return false if scroll_pressed_codes.include?(input_event.code)
+
+          output_code = get_or_record_key_code(input_event.code, input_event.code, input_event.value)
+          passthrough_event = InputEvent.new(nil, input_event.type, output_code, input_event.value)
+          write_event_with_log(passthrough_event, context: "passthrough")
+          true
+        end
+
+        def reset_scroll_keys_after_device_removed
+          return if scroll_pressed_codes.empty?
+
+          scroll_pressed_codes.clear
+          @scroll_channel.send_scroll(false)
         end
 
         # Record key name on press and return recorded name on release

--- a/lib/fusuma/plugin/remap/keyboard_remapper.rb
+++ b/lib/fusuma/plugin/remap/keyboard_remapper.rb
@@ -2,6 +2,7 @@ require "revdev"
 require "json"
 require "set"
 require_relative "layer_manager"
+require_relative "scroll_channel"
 require_relative "uinput_keyboard"
 require_relative "device_selector"
 require_relative "device_matcher"
@@ -17,6 +18,7 @@ module Fusuma
         VIRTUAL_KEYBOARD_NAME = "fusuma_virtual_keyboard"
         DEFAULT_EMERGENCY_KEYBIND = "RIGHTCTRL+LEFTCTRL".freeze
         DEVICE_CHECK_INTERVAL = 3 # seconds - interval for checking new devices
+        POINTER_SCROLL_FINGER = "POINTER_SCROLL_FINGER".freeze
 
         # Key conversion tables for better performance and readability
         KEYMAP = Revdev.constants.select { |c| c.start_with?("KEY_", "BTN_") }
@@ -29,10 +31,12 @@ module Fusuma
         # @param layer_manager [Fusuma::Plugin::Remap::LayerManager]
         # @param fusuma_writer [IO]
         # @param config [Hash]
-        def initialize(layer_manager:, fusuma_writer:, config: {})
+        # @param scroll_channel [Fusuma::Plugin::Remap::ScrollChannel]
+        def initialize(layer_manager:, fusuma_writer:, config: {}, scroll_channel: ScrollChannel.instance)
           @layer_manager = layer_manager # request to change layer
           @fusuma_writer = fusuma_writer # write event to original keyboard
           @config = config
+          @scroll_channel = scroll_channel
           @device_matcher = DeviceMatcher.new
           @device_mappings = {}
         end
@@ -136,6 +140,8 @@ module Fusuma
                   return
                 end
               end
+
+              next if handle_pressed_pointer_scroll_key(input_event)
             end
 
             remapped, is_modifier_remap = find_remapping(combo_mapping, effective_key)
@@ -177,6 +183,8 @@ module Fusuma
               MultiLogger.warn("Invalid remapped value - type: #{remapped.class}, key: #{input_key}")
               next
             end
+
+            next if handle_pointer_scroll_press(input_event, remapped)
 
             # For modifier remaps, handle specially:
             # Release currently pressed modifiers → Send remapped key → Re-press modifiers
@@ -307,6 +315,40 @@ module Fusuma
 
         def pressed_key_names
           @pressed_key_names ||= {}
+        end
+
+        def scroll_pressed_codes
+          @scroll_pressed_codes ||= Set.new
+        end
+
+        def pointer_scroll_finger_remap?(remapped)
+          remapped.to_s.upcase == POINTER_SCROLL_FINGER
+        end
+
+        def handle_pressed_pointer_scroll_key(input_event)
+          return false unless input_event.type == EV_KEY
+
+          case input_event.value
+          when 0
+            return false unless scroll_pressed_codes.delete?(input_event.code)
+
+            @scroll_channel.send_scroll(false) if scroll_pressed_codes.empty?
+            true
+          when 2
+            scroll_pressed_codes.include?(input_event.code)
+          else
+            false
+          end
+        end
+
+        def handle_pointer_scroll_press(input_event, remapped)
+          return false unless input_event.type == EV_KEY
+          return false unless input_event.value == 1
+          return false unless pointer_scroll_finger_remap?(remapped)
+
+          scroll_pressed_codes.add(input_event.code)
+          @scroll_channel.send_scroll(true)
+          true
         end
 
         # Record key name on press and return recorded name on release
@@ -573,7 +615,7 @@ module Fusuma
 
             if key_str.include?("+")
               combo_remap[key] = value
-            elsif value.is_a?(Array) || value.is_a?(Hash) || value_str&.include?("+")
+            elsif value.is_a?(Array) || value.is_a?(Hash) || value_str&.include?("+") || pointer_scroll_finger_remap?(value)
               combo_remap[key] = value
             else
               simple_remap[key] = value
@@ -722,7 +764,7 @@ module Fusuma
           end
 
           # Release all keys in reverse order
-          keys.reverse.each do |key|
+          keys.reverse_each do |key|
             code = key_to_code(key)
             next unless code
 

--- a/lib/fusuma/plugin/remap/scroll_channel.rb
+++ b/lib/fusuma/plugin/remap/scroll_channel.rb
@@ -21,8 +21,8 @@ module Fusuma
           return if @last_scroll == enabled
 
           @last_scroll = enabled
-          @writer.puts({scroll: enabled}.to_json)
-        rescue IOError, Errno::EPIPE
+          @writer.write_nonblock({scroll: enabled}.to_json + "\n")
+        rescue IO::WaitWritable, Errno::EAGAIN, IOError, Errno::EPIPE
           nil
         end
 

--- a/lib/fusuma/plugin/remap/scroll_channel.rb
+++ b/lib/fusuma/plugin/remap/scroll_channel.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "json"
+require "singleton"
+
+module Fusuma
+  module Plugin
+    module Remap
+      class ScrollChannel
+        include Singleton
+
+        attr_reader :reader, :writer
+
+        def initialize
+          @reader, @writer = IO.pipe
+          @last_scroll = nil
+        end
+
+        def send_scroll(enabled)
+          enabled = !!enabled
+          return if @last_scroll == enabled
+
+          @last_scroll = enabled
+          @writer.puts({scroll: enabled}.to_json)
+        rescue IOError, Errno::EPIPE
+          nil
+        end
+
+        def receive
+          line = @reader.gets
+          return unless line
+
+          data = JSON.parse(line)
+          return unless data.is_a?(Hash)
+
+          data["scroll"]
+        rescue IOError, JSON::ParserError
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/plugin/remap/scroll_channel.rb
+++ b/lib/fusuma/plugin/remap/scroll_channel.rb
@@ -20,15 +20,15 @@ module Fusuma
           enabled = !!enabled
           return if @last_scroll == enabled
 
-          @last_scroll = enabled
           @writer.write_nonblock({scroll: enabled}.to_json + "\n")
+          @last_scroll = enabled
         rescue IO::WaitWritable, Errno::EAGAIN, IOError, Errno::EPIPE
           nil
         end
 
         def receive
           line = @reader.gets
-          return unless line
+          return :closed unless line
 
           data = JSON.parse(line)
           return unless data.is_a?(Hash)

--- a/lib/fusuma/plugin/remap/scroll_channel.rb
+++ b/lib/fusuma/plugin/remap/scroll_channel.rb
@@ -9,6 +9,15 @@ module Fusuma
       class ScrollChannel
         include Singleton
 
+        # Remap value that designates the pointer-scroll action instead of a key
+        POINTER_SCROLL = "POINTER_SCROLL"
+
+        # @param value [Object] a remap value from the config
+        # @return [Boolean] whether it designates the pointer-scroll action
+        def self.pointer_scroll_value?(value)
+          (value.is_a?(String) || value.is_a?(Symbol)) && POINTER_SCROLL.casecmp?(value.to_s)
+        end
+
         attr_reader :reader, :writer
 
         def initialize

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -4,6 +4,8 @@ require "set"
 
 require_relative "uinput_touchpad"
 require_relative "device_selector"
+require_relative "scroll_channel"
+require_relative "two_finger_scroll_emulator"
 require "fusuma/device"
 
 module Fusuma
@@ -17,20 +19,37 @@ module Fusuma
         # @param fusuma_writer [IO]
         # @param source_touchpads [Revdev::Device]
         # @param touchpad_name_patterns [Array, String, nil] patterns for touchpad device names (for reconnection)
-        def initialize(fusuma_writer:, source_touchpads:, touchpad_name_patterns: nil)
+        # @param pointer_scroll_enabled [Boolean]
+        # @param scroll_channel [Fusuma::Plugin::Remap::ScrollChannel, nil]
+        def initialize(
+          fusuma_writer:,
+          source_touchpads:,
+          touchpad_name_patterns: nil,
+          pointer_scroll_enabled: false,
+          scroll_channel: nil,
+          uinput_factory: nil,
+          emulator_factory: nil
+        )
           @source_touchpads = source_touchpads # original touchpad
           @fusuma_writer = fusuma_writer # write event to fusuma_input
           @touchpad_name_patterns = touchpad_name_patterns # for reconnection
+          @pointer_scroll_requested = pointer_scroll_enabled
+          @pointer_scroll_enabled = pointer_scroll_enabled
+          @scroll_channel = pointer_scroll_enabled ? (scroll_channel || ScrollChannel.instance) : scroll_channel
+          @uinput_factory = uinput_factory || -> { UinputTouchpad.new "/dev/uinput" }
+          @emulator_factory = emulator_factory || ->(device) { TwoFingerScrollEmulator.new(device: device) }
+          @uinputs_by_touchpad = {}
+          @emulators_by_touchpad = {}
+          @grabbed_touchpads = []
 
           @palm_detectors = @source_touchpads.each_with_object({}) do |source_touchpad, palm_detectors|
             palm_detectors[source_touchpad] = PalmDetection.new(source_touchpad)
           end
 
           set_trap
+          setup_pointer_scroll_forwarding if @pointer_scroll_enabled
         end
 
-        # TODO: grab touchpad events and remap them
-        #       send remapped events to virtual touchpad or virtual mouse
         def run
           create_virtual_touchpad
 
@@ -41,8 +60,15 @@ module Fusuma
           prev_valid_touch = false
           prev_status = nil
           loop do
-            ios = IO.select(@source_touchpads.map(&:file)) # , @layer_manager.reader])
-            io = ios&.first&.first
+            ios = IO.select(selectable_ios)
+            readable_ios = ios&.first || []
+
+            if pointer_scroll_enabled? && readable_ios.include?(@scroll_channel.reader)
+              read_scroll_channel
+              next
+            end
+
+            io = readable_ios.first
 
             touchpad = @source_touchpads.find { |t| t.file == io }
 
@@ -65,6 +91,7 @@ module Fusuma
             # Event: time 1698456258.382693, type 4 (EV_MSC), code 5 (MSC_TIMESTAMP), value 7100
             # Event: time 1698456258.382693, -------------- SYN_REPORT ------------
             input_event = touchpad.read_input_event
+            forward_touchpad_event(touchpad, input_event)
 
             touch_state[mt_slot] ||= {MT_TRACKING_ID: nil, X: nil, Y: nil, valid_touch_point: false}
             syn_report = nil
@@ -188,20 +215,25 @@ module Fusuma
 
         def create_virtual_touchpad
           MultiLogger.info "Create virtual touchpad: #{VIRTUAL_TOUCHPAD_NAME}"
-          # NOTE: Use uinput to create a virtual touchpad that copies from first touchpad
-          uinput.create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: @source_touchpads.first)
+          if pointer_scroll_enabled?
+            @source_touchpads.each do |source_touchpad|
+              uinput_for(source_touchpad).create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: source_touchpad)
+            end
+          else
+            # NOTE: Use uinput to create a virtual touchpad that copies from first touchpad
+            uinput.create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: @source_touchpads.first)
+          end
         end
 
         # Reload touchpads after device disconnection
         # This method waits until a touchpad is reconnected
         def reload_touchpads
-          # Destroy virtual touchpad
-          begin
-            uinput.destroy
-          rescue IOError
-            # already destroyed
-          end
+          destroy_virtual_touchpads
+          ungrab_touchpads
           @uinput = nil
+          @uinputs_by_touchpad = {}
+          @emulators_by_touchpad = {}
+          @grabbed_touchpads = []
 
           # Wait and detect touchpad using DeviceSelector
           @source_touchpads = DeviceSelector.new(
@@ -214,6 +246,9 @@ module Fusuma
             palm_detectors[source_touchpad] = PalmDetection.new(source_touchpad)
           end
 
+          @pointer_scroll_enabled = @pointer_scroll_requested
+          setup_pointer_scroll_forwarding if @pointer_scroll_enabled
+
           # Recreate virtual touchpad
           create_virtual_touchpad
 
@@ -221,17 +256,100 @@ module Fusuma
         end
 
         def set_trap
-          @destroy = lambda do
+          @destroy = lambda do |status = nil|
+            destroy_virtual_touchpads
+            ungrab_touchpads
+            exit status unless status.nil?
+          end
+
+          Signal.trap(:INT) { @destroy.call(0) }
+          Signal.trap(:TERM) { @destroy.call(0) }
+        end
+
+        def pointer_scroll_enabled?
+          @pointer_scroll_enabled == true
+        end
+
+        def setup_pointer_scroll_forwarding
+          @scroll_channel ||= ScrollChannel.instance
+          grab_touchpads_for_forwarding
+          return unless pointer_scroll_enabled?
+
+          @source_touchpads.each do |source_touchpad|
+            emulator_for(source_touchpad)
+          end
+        end
+
+        def grab_touchpads_for_forwarding
+          @source_touchpads.each do |source_touchpad|
+            source_touchpad.grab
+            @grabbed_touchpads << source_touchpad
+          end
+        rescue Errno::EBUSY => e
+          MultiLogger.warn "Failed to grab touchpad for pointer scroll forwarding: #{e.message}"
+          ungrab_touchpads
+          @pointer_scroll_enabled = false
+          @scroll_channel = nil
+          @emulators_by_touchpad = {}
+        end
+
+        def selectable_ios
+          ios = @source_touchpads.map(&:file)
+          ios.unshift(@scroll_channel.reader) if pointer_scroll_enabled?
+          ios
+        end
+
+        def read_scroll_channel
+          enabled = @scroll_channel.receive
+          return if enabled.nil?
+
+          @emulators_by_touchpad.each do |touchpad, emulator|
+            write_forwarded_events(touchpad, emulator.set_scroll_mode(enabled))
+          end
+        end
+
+        def forward_touchpad_event(touchpad, input_event)
+          return unless pointer_scroll_enabled?
+
+          write_forwarded_events(touchpad, emulator_for(touchpad).process(input_event))
+        end
+
+        def write_forwarded_events(touchpad, events)
+          uinput_device = uinput_for(touchpad)
+          events.each { |event| uinput_device.write_input_event(event) }
+        end
+
+        def uinput_for(touchpad)
+          @uinputs_by_touchpad[touchpad] ||= @uinput_factory.call
+        end
+
+        def emulator_for(touchpad)
+          @emulators_by_touchpad[touchpad] ||= @emulator_factory.call(touchpad)
+        end
+
+        def destroy_virtual_touchpads
+          if @uinputs_by_touchpad&.any?
+            @uinputs_by_touchpad.each_value do |uinput_device|
+              uinput_device.destroy
+            rescue IOError
+              # already destroyed
+            end
+          else
             begin
               uinput.destroy
             rescue IOError
               # already destroyed
             end
-            exit 0
           end
+        end
 
-          Signal.trap(:INT) { @destroy.call }
-          Signal.trap(:TERM) { @destroy.call }
+        def ungrab_touchpads
+          @grabbed_touchpads.each do |touchpad|
+            touchpad.ungrab
+          rescue Errno::EINVAL, Errno::ENODEV
+            # already ungrabbed or removed
+          end
+          @grabbed_touchpads = []
         end
 
         # Detect palm touch

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -14,7 +14,7 @@ module Fusuma
       class TouchpadRemapper
         include Revdev
 
-        VIRTUAL_TOUCHPAD_NAME = "fusuma_virtual_touchpad"
+        VIRTUAL_TOUCHPAD_NAME = DeviceSelector::VIRTUAL_TOUCHPAD_NAME
 
         # @param fusuma_writer [IO]
         # @param source_touchpads [Revdev::Device]
@@ -33,9 +33,10 @@ module Fusuma
           @source_touchpads = source_touchpads # original touchpad
           @fusuma_writer = fusuma_writer # write event to fusuma_input
           @touchpad_name_patterns = touchpad_name_patterns # for reconnection
-          @pointer_scroll_requested = pointer_scroll_enabled
-          @pointer_scroll_enabled = pointer_scroll_enabled
-          @scroll_channel = pointer_scroll_enabled ? (scroll_channel || ScrollChannel.instance) : nil
+          @pointer_scroll_requested = !!pointer_scroll_enabled
+          @pointer_scroll_enabled = @pointer_scroll_requested
+          # Assigned once; whether forwarding is active is tracked solely by @pointer_scroll_enabled
+          @scroll_channel = @pointer_scroll_requested ? (scroll_channel || ScrollChannel.instance) : nil
           @uinput_factory = uinput_factory || -> { UinputTouchpad.new "/dev/uinput" }
           @emulator_factory = emulator_factory || ->(device) { TwoFingerScrollEmulator.new(device: device) }
           @uinputs_by_touchpad = {}
@@ -63,7 +64,8 @@ module Fusuma
             ios = IO.select(selectable_ios)
             readable_ios = ios&.first || []
 
-            if scroll_channel_readable?(readable_ios)
+            reader = scroll_channel_reader
+            if reader && readable_ios.include?(reader)
               read_scroll_channel
               next
             end
@@ -209,19 +211,14 @@ module Fusuma
 
         private
 
-        def uinput
-          @uinput ||= UinputTouchpad.new "/dev/uinput"
-        end
-
         def create_virtual_touchpad
           MultiLogger.info "Create virtual touchpad: #{VIRTUAL_TOUCHPAD_NAME}"
-          if pointer_scroll_enabled?
-            @source_touchpads.each do |source_touchpad|
-              uinput_for(source_touchpad).create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: source_touchpad)
-            end
-          else
-            # NOTE: Use uinput to create a virtual touchpad that copies from first touchpad
-            uinput.create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: @source_touchpads.first)
+          # NOTE: Without forwarding, a single virtual touchpad copied from the
+          # first touchpad is enough because it never receives events
+          targets = pointer_scroll_enabled? ? @source_touchpads : [@source_touchpads.first]
+          targets.each do |source_touchpad|
+            device = @uinputs_by_touchpad[source_touchpad] ||= @uinput_factory.call
+            device.create_from_device(name: VIRTUAL_TOUCHPAD_NAME, device: source_touchpad)
           end
         end
 
@@ -230,10 +227,7 @@ module Fusuma
         def reload_touchpads
           destroy_virtual_touchpads
           ungrab_touchpads
-          @uinput = nil
-          @uinputs_by_touchpad = {}
           @emulators_by_touchpad = {}
-          @grabbed_touchpads = []
 
           # Wait and detect touchpad using DeviceSelector
           @source_touchpads = DeviceSelector.new(
@@ -248,6 +242,7 @@ module Fusuma
 
           @pointer_scroll_enabled = @pointer_scroll_requested
           setup_pointer_scroll_forwarding if @pointer_scroll_enabled
+          @selectable_ios = nil
 
           # Recreate virtual touchpad
           create_virtual_touchpad
@@ -267,16 +262,15 @@ module Fusuma
         end
 
         def pointer_scroll_enabled?
-          @pointer_scroll_enabled == true
+          @pointer_scroll_enabled
         end
 
         def setup_pointer_scroll_forwarding
-          @scroll_channel ||= ScrollChannel.instance
           grab_touchpads_for_forwarding
           return unless pointer_scroll_enabled?
 
           @source_touchpads.each do |source_touchpad|
-            emulator_for(source_touchpad)
+            @emulators_by_touchpad[source_touchpad] ||= @emulator_factory.call(source_touchpad)
           end
         end
 
@@ -289,42 +283,43 @@ module Fusuma
           MultiLogger.warn "Failed to grab touchpad for pointer scroll forwarding: #{e.message}"
           ungrab_touchpads
           @pointer_scroll_enabled = false
-          @scroll_channel = nil
           @emulators_by_touchpad = {}
         end
 
+        # Rebuilt only when the sources or the scroll channel reader change
         def selectable_ios
-          ios = @source_touchpads.map(&:file)
-          reader = scroll_channel_reader
-          ios.unshift(reader) if reader
-          ios
+          @selectable_ios ||= begin
+            ios = @source_touchpads.map(&:file)
+            reader = scroll_channel_reader
+            ios.unshift(reader) if reader
+            ios
+          end
         end
 
         def read_scroll_channel
           enabled = @scroll_channel.receive
           if enabled == :closed
             close_scroll_channel_reader
-            disable_scroll_mode
+            apply_scroll_mode(false)
             return
           end
 
           return if enabled.nil?
 
+          apply_scroll_mode(enabled)
+        end
+
+        def apply_scroll_mode(enabled)
           @emulators_by_touchpad.each do |touchpad, emulator|
             write_forwarded_events(touchpad, emulator.set_scroll_mode(enabled))
           end
         end
 
-        def scroll_channel_readable?(readable_ios)
-          reader = scroll_channel_reader
-          reader && readable_ios.include?(reader)
-        end
-
         def scroll_channel_reader
-          return unless @scroll_channel
+          return unless pointer_scroll_enabled? && @scroll_channel
 
           reader = @scroll_channel.reader
-          return if reader.respond_to?(:closed?) && reader.closed?
+          return if reader.closed?
 
           reader
         rescue IOError
@@ -334,49 +329,30 @@ module Fusuma
         def close_scroll_channel_reader
           reader = @scroll_channel.reader
           reader.close unless reader.closed?
+          @selectable_ios = nil
         rescue IOError
-          nil
-        end
-
-        def disable_scroll_mode
-          @emulators_by_touchpad.each do |touchpad, emulator|
-            write_forwarded_events(touchpad, emulator.set_scroll_mode(false))
-          end
+          @selectable_ios = nil
         end
 
         def forward_touchpad_event(touchpad, input_event)
           return unless pointer_scroll_enabled?
 
-          write_forwarded_events(touchpad, emulator_for(touchpad).process(input_event))
+          emulator = @emulators_by_touchpad.fetch(touchpad)
+          write_forwarded_events(touchpad, emulator.process(input_event))
         end
 
         def write_forwarded_events(touchpad, events)
-          uinput_device = uinput_for(touchpad)
+          uinput_device = @uinputs_by_touchpad.fetch(touchpad)
           events.each { |event| uinput_device.write_input_event(event) }
         end
 
-        def uinput_for(touchpad)
-          @uinputs_by_touchpad[touchpad] ||= @uinput_factory.call
-        end
-
-        def emulator_for(touchpad)
-          @emulators_by_touchpad[touchpad] ||= @emulator_factory.call(touchpad)
-        end
-
         def destroy_virtual_touchpads
-          if @uinputs_by_touchpad&.any?
-            @uinputs_by_touchpad.each_value do |uinput_device|
-              uinput_device.destroy
-            rescue IOError
-              # already destroyed
-            end
-          else
-            begin
-              uinput.destroy
-            rescue IOError
-              # already destroyed
-            end
+          @uinputs_by_touchpad.each_value do |uinput_device|
+            uinput_device.destroy
+          rescue IOError
+            # already destroyed
           end
+          @uinputs_by_touchpad = {}
         end
 
         def ungrab_touchpads

--- a/lib/fusuma/plugin/remap/touchpad_remapper.rb
+++ b/lib/fusuma/plugin/remap/touchpad_remapper.rb
@@ -35,7 +35,7 @@ module Fusuma
           @touchpad_name_patterns = touchpad_name_patterns # for reconnection
           @pointer_scroll_requested = pointer_scroll_enabled
           @pointer_scroll_enabled = pointer_scroll_enabled
-          @scroll_channel = pointer_scroll_enabled ? (scroll_channel || ScrollChannel.instance) : scroll_channel
+          @scroll_channel = pointer_scroll_enabled ? (scroll_channel || ScrollChannel.instance) : nil
           @uinput_factory = uinput_factory || -> { UinputTouchpad.new "/dev/uinput" }
           @emulator_factory = emulator_factory || ->(device) { TwoFingerScrollEmulator.new(device: device) }
           @uinputs_by_touchpad = {}
@@ -63,7 +63,7 @@ module Fusuma
             ios = IO.select(selectable_ios)
             readable_ios = ios&.first || []
 
-            if pointer_scroll_enabled? && readable_ios.include?(@scroll_channel.reader)
+            if scroll_channel_readable?(readable_ios)
               read_scroll_channel
               next
             end
@@ -295,16 +295,52 @@ module Fusuma
 
         def selectable_ios
           ios = @source_touchpads.map(&:file)
-          ios.unshift(@scroll_channel.reader) if pointer_scroll_enabled?
+          reader = scroll_channel_reader
+          ios.unshift(reader) if reader
           ios
         end
 
         def read_scroll_channel
           enabled = @scroll_channel.receive
+          if enabled == :closed
+            close_scroll_channel_reader
+            disable_scroll_mode
+            return
+          end
+
           return if enabled.nil?
 
           @emulators_by_touchpad.each do |touchpad, emulator|
             write_forwarded_events(touchpad, emulator.set_scroll_mode(enabled))
+          end
+        end
+
+        def scroll_channel_readable?(readable_ios)
+          reader = scroll_channel_reader
+          reader && readable_ios.include?(reader)
+        end
+
+        def scroll_channel_reader
+          return unless @scroll_channel
+
+          reader = @scroll_channel.reader
+          return if reader.respond_to?(:closed?) && reader.closed?
+
+          reader
+        rescue IOError
+          nil
+        end
+
+        def close_scroll_channel_reader
+          reader = @scroll_channel.reader
+          reader.close unless reader.closed?
+        rescue IOError
+          nil
+        end
+
+        def disable_scroll_mode
+          @emulators_by_touchpad.each do |touchpad, emulator|
+            write_forwarded_events(touchpad, emulator.set_scroll_mode(false))
           end
         end
 

--- a/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
+++ b/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
@@ -1,0 +1,262 @@
+# frozen_string_literal: true
+
+require "revdev"
+require "set"
+
+module Fusuma
+  module Plugin
+    module Remap
+      class TwoFingerScrollEmulator
+        include Revdev
+
+        SYNTHETIC_TRACKING_ID_BASE = 1_000_000
+        QUINTTAP = 0x148
+
+        TOOL_BUTTONS = [
+          BTN_TOOL_FINGER,
+          BTN_TOOL_DOUBLETAP,
+          BTN_TOOL_TRIPLETAP,
+          BTN_TOOL_QUADTAP,
+          QUINTTAP
+        ].freeze
+
+        def initialize(device:)
+          @slot_min, @slot_max = axis_range(device, ABS_MT_SLOT, fallback_min: 0, fallback_max: 1)
+          @x_min, @x_max = axis_range(device, ABS_MT_POSITION_X, fallback_min: 0, fallback_max: 1000)
+          @y_min, @y_max = axis_range(device, ABS_MT_POSITION_Y, fallback_min: 0, fallback_max: 1000)
+          @x_offset_size = ((@x_max - @x_min) * 0.15).round
+
+          @slots = Hash.new { |hash, slot| hash[slot] = {tracking_id: nil, x: nil, y: nil} }
+          @current_slot = @slot_min
+          @frame_events = []
+          @frame_motion_slots = Set.new
+          @scroll_mode = false
+          @scroll_session_cancelled = false
+          @synthetic = nil
+          @tracking_sequence = 0
+        end
+
+        def set_scroll_mode(enabled)
+          enabled = !!enabled
+          return [] if @scroll_mode == enabled
+
+          @scroll_mode = enabled
+          @scroll_session_cancelled = false
+          return [] if enabled
+
+          release_synthetic_frame(real_finger_count)
+        end
+
+        def process(input_event)
+          parse_event(input_event)
+
+          unless @scroll_mode || synthetic_active?
+            return [input_event]
+          end
+
+          @frame_events << input_event
+          return [] unless syn_report?(input_event)
+
+          flush_frame
+        end
+
+        private
+
+        def axis_range(device, axis, fallback_min:, fallback_max:)
+          info = device.absinfo_for_axis(axis)
+          [info.fetch(:absmin, fallback_min), info.fetch(:absmax, fallback_max)]
+        rescue
+          [fallback_min, fallback_max]
+        end
+
+        def parse_event(input_event)
+          case input_event.type
+          when EV_ABS
+            parse_abs_event(input_event)
+          end
+        end
+
+        def parse_abs_event(input_event)
+          case input_event.code
+          when ABS_MT_SLOT
+            @current_slot = input_event.value
+            @slots[@current_slot]
+          when ABS_MT_TRACKING_ID
+            @slots[@current_slot][:tracking_id] = input_event.value
+          when ABS_MT_POSITION_X
+            record_position(:x, input_event.value)
+          when ABS_MT_POSITION_Y
+            record_position(:y, input_event.value)
+          end
+        end
+
+        def record_position(axis, value)
+          slot_state = @slots[@current_slot]
+          if real_slot_active?(@current_slot) && !slot_state[axis].nil? && slot_state[axis] != value
+            @frame_motion_slots.add(@current_slot)
+          end
+          slot_state[axis] = value
+        end
+
+        def flush_frame
+          frame = @frame_events
+          motion_slots = @frame_motion_slots
+          @frame_events = []
+          @frame_motion_slots = Set.new
+
+          count = real_finger_count
+          if synthetic_active? && (count.zero? || count >= 2)
+            @scroll_session_cancelled = true if count.zero?
+            return frame_with_synthetic_release(frame, count)
+          end
+
+          if @scroll_mode && !@scroll_session_cancelled
+            real_slot = single_real_slot
+            if !synthetic_active? && count == 1 && motion_slots.include?(real_slot)
+              activate_synthetic(real_slot)
+              return frame_with_synthetic_touch(frame, real_slot, include_tracking_id: true)
+            end
+
+            if synthetic_active? && count == 1
+              return frame_with_synthetic_touch(frame, real_slot, include_tracking_id: false)
+            end
+          end
+
+          @scroll_session_cancelled = true if @scroll_mode && count.zero?
+          frame
+        end
+
+        def synthetic_active?
+          !@synthetic.nil?
+        end
+
+        def real_slot_active?(slot)
+          tracking_id = @slots[slot][:tracking_id]
+          !tracking_id.nil? && tracking_id != -1
+        end
+
+        def real_slots
+          (@slot_min..@slot_max).select { |slot| real_slot_active?(slot) }
+        end
+
+        def real_finger_count
+          real_slots.size
+        end
+
+        def single_real_slot
+          slots = real_slots
+          (slots.size == 1) ? slots.first : nil
+        end
+
+        def activate_synthetic(real_slot)
+          @tracking_sequence += 1
+          real_x = @slots[real_slot][:x]
+          offset = (real_x > ((@x_min + @x_max) / 2)) ? -@x_offset_size : @x_offset_size
+
+          @synthetic = {
+            slot: available_synthetic_slot,
+            tracking_id: SYNTHETIC_TRACKING_ID_BASE + @tracking_sequence,
+            offset: offset
+          }
+        end
+
+        def available_synthetic_slot
+          real = real_slots.to_set
+          (@slot_min..@slot_max).to_a.reverse.find { |slot| !real.include?(slot) }
+        end
+
+        def frame_with_synthetic_touch(frame, real_slot, include_tracking_id:)
+          return frame unless real_slot && @synthetic
+
+          without_syn = frame_without_syn_or_tool_buttons(frame)
+          synthetic_x, synthetic_y = synthetic_position_for(real_slot)
+
+          events = without_syn.dup
+          events << input_event(EV_ABS, ABS_MT_SLOT, @synthetic[:slot])
+          events << input_event(EV_ABS, ABS_MT_TRACKING_ID, @synthetic[:tracking_id]) if include_tracking_id
+          events << input_event(EV_ABS, ABS_MT_POSITION_X, synthetic_x)
+          events << input_event(EV_ABS, ABS_MT_POSITION_Y, synthetic_y)
+          events.concat(tool_events(2))
+          events << input_event(EV_KEY, BTN_TOUCH, 1) unless frame_has_btn_touch?(frame)
+          events << input_event(EV_ABS, ABS_MT_SLOT, real_slot)
+          events << syn_event
+          events
+        end
+
+        def frame_with_synthetic_release(frame, real_count)
+          events = frame_without_syn_or_tool_buttons(frame).dup
+          events.concat(release_synthetic_events(real_count, restore_slot: single_real_slot || @current_slot))
+          events << syn_event
+          events
+        end
+
+        def release_synthetic_frame(real_count)
+          return [] unless synthetic_active?
+
+          events = release_synthetic_events(real_count, restore_slot: single_real_slot || @current_slot)
+          events << syn_event
+          events
+        end
+
+        def release_synthetic_events(real_count, restore_slot:)
+          synthetic_slot = @synthetic[:slot]
+          @synthetic = nil
+
+          events = [
+            input_event(EV_ABS, ABS_MT_SLOT, synthetic_slot),
+            input_event(EV_ABS, ABS_MT_TRACKING_ID, -1)
+          ]
+          events.concat(tool_events(real_count))
+          events << input_event(EV_KEY, BTN_TOUCH, real_count.positive? ? 1 : 0)
+          events << input_event(EV_ABS, ABS_MT_SLOT, restore_slot) unless restore_slot.nil?
+          events
+        end
+
+        def synthetic_position_for(real_slot)
+          real = @slots[real_slot]
+          x = clamp(real[:x] + @synthetic[:offset], @x_min, @x_max)
+          y = clamp(real[:y], @y_min, @y_max)
+          [x, y]
+        end
+
+        def clamp(value, min, max)
+          value.clamp(min, max)
+        end
+
+        def tool_events(finger_count)
+          [
+            input_event(EV_KEY, BTN_TOOL_FINGER, (finger_count == 1) ? 1 : 0),
+            input_event(EV_KEY, BTN_TOOL_DOUBLETAP, (finger_count == 2) ? 1 : 0),
+            input_event(EV_KEY, BTN_TOOL_TRIPLETAP, (finger_count == 3) ? 1 : 0),
+            input_event(EV_KEY, BTN_TOOL_QUADTAP, (finger_count == 4) ? 1 : 0),
+            input_event(EV_KEY, QUINTTAP, (finger_count >= 5) ? 1 : 0)
+          ]
+        end
+
+        def frame_without_syn_or_tool_buttons(frame)
+          frame.reject { |input_event| syn_report?(input_event) || tool_button?(input_event) }
+        end
+
+        def frame_has_btn_touch?(frame)
+          frame.any? { |input_event| input_event.type == EV_KEY && input_event.code == BTN_TOUCH }
+        end
+
+        def tool_button?(input_event)
+          input_event.type == EV_KEY && TOOL_BUTTONS.include?(input_event.code)
+        end
+
+        def syn_report?(input_event)
+          input_event.type == EV_SYN && input_event.code == SYN_REPORT
+        end
+
+        def syn_event
+          input_event(EV_SYN, SYN_REPORT, 0)
+        end
+
+        def input_event(type, code, value)
+          Revdev::InputEvent.new(nil, type, code, value)
+        end
+      end
+    end
+  end
+end

--- a/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
+++ b/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
@@ -31,7 +31,6 @@ module Fusuma
           @frame_events = []
           @frame_motion_slots = Set.new
           @scroll_mode = false
-          @scroll_session_cancelled = false
           @synthetic = nil
           @tracking_sequence = 0
         end
@@ -41,7 +40,6 @@ module Fusuma
           return [] if @scroll_mode == enabled
 
           @scroll_mode = enabled
-          @scroll_session_cancelled = false
           return [] if enabled
 
           release_synthetic_frame(real_finger_count)
@@ -82,7 +80,7 @@ module Fusuma
             @current_slot = input_event.value
             @slots[@current_slot]
           when ABS_MT_TRACKING_ID
-            @slots[@current_slot][:tracking_id] = input_event.value
+            @slots[@current_slot] = {tracking_id: input_event.value, x: nil, y: nil}
           when ABS_MT_POSITION_X
             record_position(:x, input_event.value)
           when ABS_MT_POSITION_Y
@@ -106,11 +104,10 @@ module Fusuma
 
           count = real_finger_count
           if synthetic_active? && (count.zero? || count >= 2)
-            @scroll_session_cancelled = true if count.zero?
             return frame_with_synthetic_release(frame, count)
           end
 
-          if @scroll_mode && !@scroll_session_cancelled
+          if @scroll_mode
             real_slot = single_real_slot
             if !synthetic_active? && count == 1 && motion_slots.include?(real_slot)
               activate_synthetic(real_slot)
@@ -122,7 +119,6 @@ module Fusuma
             end
           end
 
-          @scroll_session_cancelled = true if @scroll_mode && count.zero?
           frame
         end
 

--- a/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
+++ b/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
@@ -110,7 +110,8 @@ module Fusuma
           if @scroll_mode
             real_slot = single_real_slot
             if !synthetic_active? && count == 1 && motion_slots.include?(real_slot)
-              activate_synthetic(real_slot)
+              return frame unless activate_synthetic(real_slot)
+
               return frame_with_synthetic_touch(frame, real_slot, include_tracking_id: true)
             end
 
@@ -145,15 +146,19 @@ module Fusuma
         end
 
         def activate_synthetic(real_slot)
+          synthetic_slot = available_synthetic_slot
+          return false unless synthetic_slot
+
           @tracking_sequence += 1
           real_x = @slots[real_slot][:x]
           offset = (real_x > ((@x_min + @x_max) / 2)) ? -@x_offset_size : @x_offset_size
 
           @synthetic = {
-            slot: available_synthetic_slot,
+            slot: synthetic_slot,
             tracking_id: SYNTHETIC_TRACKING_ID_BASE + @tracking_sequence,
             offset: offset
           }
+          true
         end
 
         def available_synthetic_slot

--- a/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
+++ b/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
@@ -39,7 +39,7 @@ module Fusuma
           enabled = !!enabled
           return [] if @scroll_mode == enabled
 
-          buffered_frame = drain_frame_events
+          buffered_frame, _ = drain_frame_events
           @scroll_mode = enabled
           return buffered_frame if enabled
 
@@ -81,7 +81,6 @@ module Fusuma
           case input_event.code
           when ABS_MT_SLOT
             @current_slot = input_event.value
-            @slots[@current_slot]
           when ABS_MT_TRACKING_ID
             slot_state = @slots[@current_slot]
             slot_state[:tracking_id] = input_event.value
@@ -107,24 +106,23 @@ module Fusuma
 
         def drain_frame_events
           frame = @frame_events
-          @frame_events = []
-          @frame_motion_slots = Set.new
-          frame
-        end
-
-        def flush_frame
-          frame = @frame_events
           motion_slots = @frame_motion_slots
           @frame_events = []
           @frame_motion_slots = Set.new
+          [frame, motion_slots]
+        end
 
-          count = real_finger_count
+        def flush_frame
+          frame, motion_slots = drain_frame_events
+
+          active_slots = real_slots
+          count = active_slots.size
           if synthetic_active? && (count.zero? || count >= 2)
             return frame_with_synthetic_release(frame, count)
           end
 
           if @scroll_mode
-            real_slot = single_real_slot
+            real_slot = (count == 1) ? active_slots.first : nil
             if !synthetic_active? && count == 1 && motion_slots.include?(real_slot)
               return frame unless activate_synthetic(real_slot)
 
@@ -181,30 +179,32 @@ module Fusuma
         end
 
         def available_synthetic_slot
-          real = real_slots.to_set
-          (@slot_min..@slot_max).to_a.reverse.find { |slot| !real.include?(slot) }
+          @slot_max.downto(@slot_min).find { |slot| !real_slot_active?(slot) }
         end
 
         def frame_with_synthetic_touch(frame, real_slot, include_tracking_id:)
           return frame unless real_slot && @synthetic
 
-          without_syn = frame_without_syn_or_tool_buttons(frame)
           synthetic_x, synthetic_y = synthetic_position_for(real_slot)
 
-          events = without_syn.dup
+          events = frame_without_syn_or_tool_buttons(frame)
           events << input_event(EV_ABS, ABS_MT_SLOT, @synthetic[:slot])
           events << input_event(EV_ABS, ABS_MT_TRACKING_ID, @synthetic[:tracking_id]) if include_tracking_id
           events << input_event(EV_ABS, ABS_MT_POSITION_X, synthetic_x)
           events << input_event(EV_ABS, ABS_MT_POSITION_Y, synthetic_y)
-          events.concat(tool_events(2))
-          events << input_event(EV_KEY, BTN_TOUCH, 1) unless frame_has_btn_touch?(frame)
+          if include_tracking_id
+            # Tool/touch state only changes when the synthetic finger appears;
+            # the kernel keeps key state between frames, so mirror frames need no re-emission
+            events.concat(tool_events(2))
+            events << input_event(EV_KEY, BTN_TOUCH, 1) unless frame_has_btn_touch?(frame)
+          end
           events << input_event(EV_ABS, ABS_MT_SLOT, real_slot)
           events << syn_event
           events
         end
 
         def frame_with_synthetic_release(frame, real_count)
-          events = frame_without_syn_or_tool_buttons(frame).dup
+          events = frame_without_syn_or_tool_buttons(frame)
           events.concat(release_synthetic_events(real_count, restore_slot: single_real_slot || @current_slot))
           events << syn_event
           events
@@ -232,13 +232,9 @@ module Fusuma
 
         def synthetic_position_for(real_slot)
           real = @slots[real_slot]
-          x = clamp(real[:x] + @synthetic[:offset], @x_min, @x_max)
-          y = clamp(real[:y], @y_min, @y_max)
+          x = (real[:x] + @synthetic[:offset]).clamp(@x_min, @x_max)
+          y = real[:y].clamp(@y_min, @y_max)
           [x, y]
-        end
-
-        def clamp(value, min, max)
-          value.clamp(min, max)
         end
 
         def tool_events(finger_count)

--- a/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
+++ b/lib/fusuma/plugin/remap/two_finger_scroll_emulator.rb
@@ -26,7 +26,7 @@ module Fusuma
           @y_min, @y_max = axis_range(device, ABS_MT_POSITION_Y, fallback_min: 0, fallback_max: 1000)
           @x_offset_size = ((@x_max - @x_min) * 0.15).round
 
-          @slots = Hash.new { |hash, slot| hash[slot] = {tracking_id: nil, x: nil, y: nil} }
+          @slots = Hash.new { |hash, slot| hash[slot] = {tracking_id: nil, x: nil, y: nil, new_touch: false} }
           @current_slot = @slot_min
           @frame_events = []
           @frame_motion_slots = Set.new
@@ -39,10 +39,11 @@ module Fusuma
           enabled = !!enabled
           return [] if @scroll_mode == enabled
 
+          buffered_frame = drain_frame_events
           @scroll_mode = enabled
-          return [] if enabled
+          return buffered_frame if enabled
 
-          release_synthetic_frame(real_finger_count)
+          buffered_frame + release_synthetic_frame(real_finger_count)
         end
 
         def process(input_event)
@@ -71,6 +72,8 @@ module Fusuma
           case input_event.type
           when EV_ABS
             parse_abs_event(input_event)
+          when EV_SYN
+            clear_new_touch_flags if syn_report?(input_event)
           end
         end
 
@@ -80,7 +83,9 @@ module Fusuma
             @current_slot = input_event.value
             @slots[@current_slot]
           when ABS_MT_TRACKING_ID
-            @slots[@current_slot] = {tracking_id: input_event.value, x: nil, y: nil}
+            slot_state = @slots[@current_slot]
+            slot_state[:tracking_id] = input_event.value
+            slot_state[:new_touch] = input_event.value != -1
           when ABS_MT_POSITION_X
             record_position(:x, input_event.value)
           when ABS_MT_POSITION_Y
@@ -90,10 +95,21 @@ module Fusuma
 
         def record_position(axis, value)
           slot_state = @slots[@current_slot]
-          if real_slot_active?(@current_slot) && !slot_state[axis].nil? && slot_state[axis] != value
+          if real_slot_active?(@current_slot) && !slot_state[:new_touch] && !slot_state[axis].nil? && slot_state[axis] != value
             @frame_motion_slots.add(@current_slot)
           end
           slot_state[axis] = value
+        end
+
+        def clear_new_touch_flags
+          @slots.each_value { |slot_state| slot_state[:new_touch] = false }
+        end
+
+        def drain_frame_events
+          frame = @frame_events
+          @frame_events = []
+          @frame_motion_slots = Set.new
+          frame
         end
 
         def flush_frame
@@ -149,8 +165,11 @@ module Fusuma
           synthetic_slot = available_synthetic_slot
           return false unless synthetic_slot
 
+          real = @slots[real_slot]
+          return false if real[:x].nil? || real[:y].nil?
+
           @tracking_sequence += 1
-          real_x = @slots[real_slot][:x]
+          real_x = real[:x]
           offset = (real_x > ((@x_min + @x_max) / 2)) ? -@x_offset_size : @x_offset_size
 
           @synthetic = {
@@ -203,10 +222,8 @@ module Fusuma
           synthetic_slot = @synthetic[:slot]
           @synthetic = nil
 
-          events = [
-            input_event(EV_ABS, ABS_MT_SLOT, synthetic_slot),
-            input_event(EV_ABS, ABS_MT_TRACKING_ID, -1)
-          ]
+          events = [input_event(EV_ABS, ABS_MT_SLOT, synthetic_slot)]
+          events << input_event(EV_ABS, ABS_MT_TRACKING_ID, -1) unless real_slot_active?(synthetic_slot)
           events.concat(tool_events(real_count))
           events << input_event(EV_KEY, BTN_TOUCH, real_count.positive? ? 1 : 0)
           events << input_event(EV_ABS, ABS_MT_SLOT, restore_slot) unless restore_slot.nil?

--- a/lib/fusuma/plugin/remap/uinput_touchpad.rb
+++ b/lib/fusuma/plugin/remap/uinput_touchpad.rb
@@ -36,7 +36,12 @@ class UinputTouchpad < Ruinput::UinputDevice
 
     @file.syswrite uud.to_byte_string
 
-    set_supported_events(supported)
+    if supported[:events].empty?
+      Fusuma::MultiLogger.warn("Failed to probe touchpad capabilities; falling back to static event setup")
+      set_all_events
+    else
+      set_supported_events(supported)
+    end
 
     @file.ioctl UI_DEV_CREATE, nil
     @is_created = true

--- a/lib/fusuma/plugin/remap/uinput_touchpad.rb
+++ b/lib/fusuma/plugin/remap/uinput_touchpad.rb
@@ -31,7 +31,7 @@ class UinputTouchpad < Ruinput::UinputDevice
       absmin: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absmin] } },
       absfuzz: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absfuzz] } },
       absflat: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absflat] } },
-      resolution: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:resolution] || v[:absresolution] || 0 } }
+      resolution: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:resolution] || 0 } }
     })
 
     @file.syswrite uud.to_byte_string
@@ -172,7 +172,7 @@ class UinputTouchpad < Ruinput::UinputDevice
       abs: supported_codes(device, eviocgbit(Revdev::EV_ABS, bit_bytes(Revdev::ABS_CNT)), Revdev::ABS_CNT),
       rels: supported_codes(device, eviocgbit(Revdev::EV_REL, bit_bytes(Revdev::REL_CNT)), Revdev::REL_CNT),
       mscs: supported_codes(device, eviocgbit(Revdev::EV_MSC, bit_bytes(Revdev::MSC_CNT)), Revdev::MSC_CNT),
-      props: supported_codes(device, eviocgprop(bit_bytes(Revdev::INPUT_PROP_CNT)), Revdev::INPUT_PROP_CNT)
+      props: supported_codes(device, Revdev::EVIOCGPROP, Revdev::INPUT_PROP_CNT)
     }
   end
 
@@ -191,10 +191,6 @@ class UinputTouchpad < Ruinput::UinputDevice
 
   def eviocgbit(event_type, length)
     ioc_read("E", 0x20 + event_type, length)
-  end
-
-  def eviocgprop(length)
-    ioc_read("E", 0x09, length)
   end
 
   def ioc_read(type, number, size)

--- a/lib/fusuma/plugin/remap/uinput_touchpad.rb
+++ b/lib/fusuma/plugin/remap/uinput_touchpad.rb
@@ -3,6 +3,9 @@ require "ruinput"
 class UinputTouchpad < Ruinput::UinputDevice
   include Ruinput
 
+  UI_SET_PROPBIT_FALLBACK = 0x4004556E
+  UINPUT_SET_PROPBIT = Ruinput.const_defined?(:UI_SET_PROPBIT) ? Ruinput::UI_SET_PROPBIT : UI_SET_PROPBIT_FALLBACK
+
   # create from original event device
   # copy absinfo using eviocgabs
   def create_from_device(name:, device:)
@@ -15,15 +18,10 @@ class UinputTouchpad < Ruinput::UinputDevice
       }
     )
 
-    absinfo = {
-      Revdev::ABS_X => device.absinfo_for_axis(Revdev::ABS_X),
-      Revdev::ABS_Y => device.absinfo_for_axis(Revdev::ABS_Y),
-      Revdev::ABS_MT_POSITION_X => device.absinfo_for_axis(Revdev::ABS_MT_POSITION_X),
-      Revdev::ABS_MT_POSITION_Y => device.absinfo_for_axis(Revdev::ABS_MT_POSITION_Y),
-      Revdev::ABS_MT_SLOT => device.absinfo_for_axis(Revdev::ABS_MT_SLOT),
-      Revdev::ABS_MT_TOOL_TYPE => device.absinfo_for_axis(Revdev::ABS_MT_TOOL_TYPE),
-      Revdev::ABS_MT_TRACKING_ID => device.absinfo_for_axis(Revdev::ABS_MT_TRACKING_ID)
-    }
+    supported = supported_capabilities(device)
+    absinfo = supported[:abs].to_h do |axis|
+      [axis, device.absinfo_for_axis(axis)]
+    end
 
     uud = Ruinput::UinputUserDev.new({
       name: name,
@@ -33,15 +31,26 @@ class UinputTouchpad < Ruinput::UinputDevice
       absmin: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absmin] } },
       absfuzz: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absfuzz] } },
       absflat: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:absflat] } },
-      resolution: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:resolution] } }
+      resolution: Array.new(Revdev::ABS_CNT, 0).tap { |a| absinfo.each { |k, v| a[k] = v[:resolution] || v[:absresolution] || 0 } }
     })
 
     @file.syswrite uud.to_byte_string
 
-    set_all_events
+    set_supported_events(supported)
 
     @file.ioctl UI_DEV_CREATE, nil
     @is_created = true
+  end
+
+  def set_supported_events(supported)
+    raise "invalid method call: this uinput is already created" if @is_created
+
+    supported[:events].each { |event_type| @file.ioctl UI_SET_EVBIT, event_type }
+    supported[:keys].each { |code| @file.ioctl UI_SET_KEYBIT, code }
+    supported[:abs].each { |axis| @file.ioctl UI_SET_ABSBIT, axis }
+    supported[:rels].each { |code| @file.ioctl UI_SET_RELBIT, code }
+    supported[:mscs].each { |code| @file.ioctl UI_SET_MSCBIT, code }
+    supported[:props].each { |prop| @file.ioctl UINPUT_SET_PROPBIT, prop }
   end
 
   def set_all_events
@@ -147,6 +156,45 @@ class UinputTouchpad < Ruinput::UinputDevice
         # puts "skipping #{i} (#{Revdev::REVERSE_MAPS[:MSC][i]})"
       end
     end
+  end
+
+  private
+
+  def supported_capabilities(device)
+    {
+      events: supported_codes(device, eviocgbit(0, bit_bytes(Revdev::EV_CNT)), Revdev::EV_CNT),
+      keys: supported_codes(device, eviocgbit(Revdev::EV_KEY, bit_bytes(Revdev::KEY_CNT)), Revdev::KEY_CNT),
+      abs: supported_codes(device, eviocgbit(Revdev::EV_ABS, bit_bytes(Revdev::ABS_CNT)), Revdev::ABS_CNT),
+      rels: supported_codes(device, eviocgbit(Revdev::EV_REL, bit_bytes(Revdev::REL_CNT)), Revdev::REL_CNT),
+      mscs: supported_codes(device, eviocgbit(Revdev::EV_MSC, bit_bytes(Revdev::MSC_CNT)), Revdev::MSC_CNT),
+      props: supported_codes(device, eviocgprop(bit_bytes(Revdev::INPUT_PROP_CNT)), Revdev::INPUT_PROP_CNT)
+    }
+  end
+
+  def supported_codes(device, request, max)
+    bytes = device.read_ioctl_with(request).unpack("C*")
+    (0...max).select do |code|
+      (bytes[code / 8].to_i & (1 << (code % 8))) != 0
+    end
+  rescue Errno::EINVAL, IOError
+    []
+  end
+
+  def bit_bytes(max)
+    (max + 7) / 8
+  end
+
+  def eviocgbit(event_type, length)
+    ioc_read("E", 0x20 + event_type, length)
+  end
+
+  def eviocgprop(length)
+    ioc_read("E", 0x09, length)
+  end
+
+  def ioc_read(type, number, size)
+    # Linux _IOR(type, nr, size): direction READ is 2, type is the ioctl group byte.
+    (2 << 30) | (size << 16) | (type.ord << 8) | number
   end
 end
 

--- a/spec/fusuma/plugin/inputs/remap_keyboard_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_keyboard_input_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "fusuma/plugin/inputs/input"
 
 require "fusuma/plugin/inputs/remap_keyboard_input"
+require "fusuma/plugin/remap/scroll_channel"
 
 # require "fusuma/plugin/events/records/keypress_record"
 
@@ -26,6 +27,33 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapKeyboardInput do
       it "returns an Event" do
         expect(instance.create_event(record: record)).to be_a_kind_of(Fusuma::Plugin::Events::Event)
       end
+    end
+  end
+
+  describe "#setup_remapper" do
+    let(:layer_manager) do
+      instance_double(
+        "Fusuma::Plugin::Remap::LayerManager",
+        reader: double(close: nil),
+        writer: double(close: nil)
+      )
+    end
+    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
+
+    before do
+      allow_any_instance_of(described_class).to receive(:fork).and_yield
+      allow_any_instance_of(described_class).to receive(:config_params).and_return(nil)
+      allow(IO).to receive(:pipe).and_return([double(close: nil), double(close: nil)])
+      allow(Fusuma::Plugin::Remap::LayerManager).to receive(:instance).and_return(layer_manager)
+      allow(Fusuma::Plugin::Remap::ScrollChannel).to receive(:instance).and_return(scroll_channel)
+    end
+
+    it "passes the pre-fork ScrollChannel singleton to KeyboardRemapper" do
+      expect(Fusuma::Plugin::Remap::KeyboardRemapper).to receive(:new).with(
+        hash_including(scroll_channel: scroll_channel)
+      ).and_return(double(run: nil))
+
+      described_class.new
     end
   end
 end

--- a/spec/fusuma/plugin/inputs/remap_keyboard_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_keyboard_input_spec.rb
@@ -38,7 +38,15 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapKeyboardInput do
         writer: double(close: nil)
       )
     end
-    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
+    let(:scroll_reader) { instance_double("IO", close: nil) }
+    let(:scroll_writer) { instance_double("IO", close: nil) }
+    let(:scroll_channel) do
+      instance_double(
+        "Fusuma::Plugin::Remap::ScrollChannel",
+        reader: scroll_reader,
+        writer: scroll_writer
+      )
+    end
 
     before do
       allow_any_instance_of(described_class).to receive(:fork).and_yield
@@ -52,6 +60,14 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapKeyboardInput do
       expect(Fusuma::Plugin::Remap::KeyboardRemapper).to receive(:new).with(
         hash_including(scroll_channel: scroll_channel)
       ).and_return(double(run: nil))
+
+      described_class.new
+    end
+
+    it "closes the unused scroll channel reader inside the child fork" do
+      allow(Fusuma::Plugin::Remap::KeyboardRemapper).to receive(:new).and_return(double(run: nil))
+
+      expect(scroll_reader).to receive(:close)
 
       described_class.new
     end

--- a/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
@@ -157,6 +157,15 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
 
         expect(input.send(:pointer_scroll_configured?)).to be false
       end
+
+      it "warns and returns false when config detection fails" do
+        input = described_class.new
+        allow(Fusuma::Config).to receive(:instance).and_raise(StandardError, "broken config")
+
+        expect(Fusuma::MultiLogger).to receive(:warn).with("Failed to detect POINTER_SCROLL config: broken config")
+
+        expect(input.send(:pointer_scroll_configured?)).to be false
+      end
     end
 
     describe "non-blocking behavior" do

--- a/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 require "fusuma/plugin/inputs/input"
 require "fusuma/plugin/inputs/remap_touchpad_input"
 require "fusuma/plugin/remap/device_selector"
+require "fusuma/plugin/remap/scroll_channel"
 require "fusuma/device"
 
 RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
@@ -71,6 +72,60 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
         ).and_return(double(run: nil))
 
         described_class.new
+      end
+    end
+
+    describe "pointer scroll wiring" do
+      let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
+
+      before do
+        allow_any_instance_of(described_class).to receive(:config_params).with(:touchpad_name_patterns).and_return(["Touchpad"])
+        allow(IO).to receive(:pipe).and_return([double(close: nil), double(close: nil)])
+        allow_any_instance_of(Fusuma::Plugin::Remap::DeviceSelector).to receive(:select).and_return([])
+        allow(Fusuma::Plugin::Remap::ScrollChannel).to receive(:instance).and_return(scroll_channel)
+      end
+
+      it "passes pointer_scroll_enabled when POINTER_SCROLL_FINGER appears in any remap value" do
+        config = instance_double("Fusuma::Config", keymap: [
+          {remap: {S: "POINTER_SCROLL_FINGER"}},
+          {context: {thumbsense: true}, remap: {D: "BTN_LEFT"}}
+        ])
+        allow(Fusuma::Config).to receive(:instance).and_return(config)
+
+        expect(Fusuma::Plugin::Remap::TouchpadRemapper).to receive(:new).with(
+          hash_including(pointer_scroll_enabled: true, scroll_channel: scroll_channel)
+        ).and_return(double(run: nil))
+
+        described_class.new
+      end
+
+      it "leaves forwarding disabled when the token is absent" do
+        config = instance_double("Fusuma::Config", keymap: [
+          {remap: {S: "BTN_LEFT"}}
+        ])
+        allow(Fusuma::Config).to receive(:instance).and_return(config)
+
+        expect(Fusuma::Plugin::Remap::TouchpadRemapper).to receive(:new).with(
+          hash_including(pointer_scroll_enabled: false, scroll_channel: scroll_channel)
+        ).and_return(double(run: nil))
+
+        described_class.new
+      end
+    end
+
+    describe "#pointer_scroll_finger_configured?" do
+      before do
+        allow_any_instance_of(described_class).to receive(:setup_remapper)
+      end
+
+      it "detects the token case-insensitively in nested remap values" do
+        input = described_class.new
+        config = instance_double("Fusuma::Config", keymap: [
+          {remap: {S: ["BTN_LEFT", "pointer_scroll_finger"]}}
+        ])
+        allow(Fusuma::Config).to receive(:instance).and_return(config)
+
+        expect(input.send(:pointer_scroll_finger_configured?)).to be true
       end
     end
 

--- a/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
@@ -85,9 +85,9 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
         allow(Fusuma::Plugin::Remap::ScrollChannel).to receive(:instance).and_return(scroll_channel)
       end
 
-      it "passes pointer_scroll_enabled when POINTER_SCROLL_FINGER appears in any remap value" do
+      it "passes pointer_scroll_enabled when POINTER_SCROLL appears in any remap value" do
         config = instance_double("Fusuma::Config", keymap: [
-          {remap: {S: "POINTER_SCROLL_FINGER"}},
+          {remap: {S: "POINTER_SCROLL"}},
           {context: {thumbsense: true}, remap: {D: "BTN_LEFT"}}
         ])
         allow(Fusuma::Config).to receive(:instance).and_return(config)
@@ -113,7 +113,7 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
       end
     end
 
-    describe "#pointer_scroll_finger_configured?" do
+    describe "#pointer_scroll_configured?" do
       before do
         allow_any_instance_of(described_class).to receive(:setup_remapper)
       end
@@ -121,11 +121,21 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
       it "detects the token case-insensitively in nested remap values" do
         input = described_class.new
         config = instance_double("Fusuma::Config", keymap: [
-          {remap: {S: ["BTN_LEFT", "pointer_scroll_finger"]}}
+          {remap: {S: ["BTN_LEFT", "pointer_scroll"]}}
         ])
         allow(Fusuma::Config).to receive(:instance).and_return(config)
 
-        expect(input.send(:pointer_scroll_finger_configured?)).to be true
+        expect(input.send(:pointer_scroll_configured?)).to be true
+      end
+
+      it "does not detect the legacy POINTER_SCROLL_FINGER token" do
+        input = described_class.new
+        config = instance_double("Fusuma::Config", keymap: [
+          {remap: {S: "POINTER_SCROLL_FINGER"}}
+        ])
+        allow(Fusuma::Config).to receive(:instance).and_return(config)
+
+        expect(input.send(:pointer_scroll_configured?)).to be false
       end
     end
 

--- a/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
+++ b/spec/fusuma/plugin/inputs/remap_touchpad_input_spec.rb
@@ -19,9 +19,20 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
   end
 
   describe "#setup_remapper" do
+    let(:scroll_reader) { instance_double("IO", close: nil) }
+    let(:scroll_writer) { instance_double("IO", close: nil) }
+    let(:scroll_channel) do
+      instance_double(
+        "Fusuma::Plugin::Remap::ScrollChannel",
+        reader: scroll_reader,
+        writer: scroll_writer
+      )
+    end
+
     before do
       allow_any_instance_of(described_class).to receive(:fork).and_yield
       allow_any_instance_of(described_class).to receive(:config_params).and_return(nil)
+      allow(Fusuma::Plugin::Remap::ScrollChannel).to receive(:instance).and_return(scroll_channel)
     end
 
     describe "IO pipe creation" do
@@ -76,13 +87,10 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
     end
 
     describe "pointer scroll wiring" do
-      let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
-
       before do
         allow_any_instance_of(described_class).to receive(:config_params).with(:touchpad_name_patterns).and_return(["Touchpad"])
         allow(IO).to receive(:pipe).and_return([double(close: nil), double(close: nil)])
         allow_any_instance_of(Fusuma::Plugin::Remap::DeviceSelector).to receive(:select).and_return([])
-        allow(Fusuma::Plugin::Remap::ScrollChannel).to receive(:instance).and_return(scroll_channel)
       end
 
       it "passes pointer_scroll_enabled when POINTER_SCROLL appears in any remap value" do
@@ -108,6 +116,18 @@ RSpec.describe Fusuma::Plugin::Inputs::RemapTouchpadInput do
         expect(Fusuma::Plugin::Remap::TouchpadRemapper).to receive(:new).with(
           hash_including(pointer_scroll_enabled: false, scroll_channel: scroll_channel)
         ).and_return(double(run: nil))
+
+        described_class.new
+      end
+
+      it "closes the unused scroll channel writer inside the child fork" do
+        config = instance_double("Fusuma::Config", keymap: [
+          {remap: {S: "POINTER_SCROLL"}}
+        ])
+        allow(Fusuma::Config).to receive(:instance).and_return(config)
+        allow(Fusuma::Plugin::Remap::TouchpadRemapper).to receive(:new).and_return(double(run: nil))
+
+        expect(scroll_writer).to receive(:close)
 
         described_class.new
       end

--- a/spec/fusuma/plugin/remap/device_matcher_spec.rb
+++ b/spec/fusuma/plugin/remap/device_matcher_spec.rb
@@ -75,8 +75,8 @@ RSpec.describe Fusuma::Plugin::Remap::DeviceMatcher do
         .once
         .and_return([{context: {device: "HHKB"}, remap: {}}])
 
-      matcher.match("HHKB")
-      matcher.match("HHKB")
+      matcher.public_send(:match, "HHKB")
+      matcher.public_send(:match, "HHKB")
     end
   end
 end

--- a/spec/fusuma/plugin/remap/device_selector_spec.rb
+++ b/spec/fusuma/plugin/remap/device_selector_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe Fusuma::Plugin::Remap::DeviceSelector do
       end
     end
 
+    context "when virtual remap devices match the configured patterns" do
+      let(:name_patterns) { ["touchpad", "keyboard"] }
+      let(:event_device) { double(Revdev::EventDevice, name: "Physical touchpad") }
+
+      before do
+        allow(Fusuma::Device).to receive(:all).and_return([
+          Fusuma::Device.new(name: "Physical touchpad", id: "event0", available: true),
+          Fusuma::Device.new(name: "fusuma_virtual_touchpad", id: "event1", available: true),
+          Fusuma::Device.new(name: "fusuma_virtual_keyboard", id: "event2", available: true)
+        ])
+        allow(Revdev::EventDevice).to receive(:new).and_return(event_device)
+      end
+
+      it "excludes fusuma virtual devices before opening event devices" do
+        selector.select
+
+        expect(Revdev::EventDevice).to have_received(:new).once.with("/dev/input/event0")
+        expect(Revdev::EventDevice).not_to have_received(:new).with("/dev/input/event1")
+        expect(Revdev::EventDevice).not_to have_received(:new).with("/dev/input/event2")
+      end
+    end
+
     context "when device is not found and wait: false" do
       before do
         allow(Fusuma::Device).to receive(:all).and_return([])
@@ -92,7 +114,8 @@ RSpec.describe Fusuma::Plugin::Remap::DeviceSelector do
 
       before do
         allow(Fusuma::Device).to receive(:available).and_return([
-          Fusuma::Device.new(name: "Touchpad", id: "event0", available: true)
+          Fusuma::Device.new(name: "Touchpad", id: "event0", available: true),
+          Fusuma::Device.new(name: "fusuma_virtual_touchpad", id: "event1", available: true)
         ])
         allow(Revdev::EventDevice).to receive(:new).and_return(event_device)
       end
@@ -106,6 +129,13 @@ RSpec.describe Fusuma::Plugin::Remap::DeviceSelector do
         result = selector.select
         expect(result).to be_a_kind_of(Array)
         expect(result.first).to eq(event_device)
+      end
+
+      it "excludes virtual devices from Device.available results" do
+        selector.select
+
+        expect(Revdev::EventDevice).to have_received(:new).once.with("/dev/input/event0")
+        expect(Revdev::EventDevice).not_to have_received(:new).with("/dev/input/event1")
       end
     end
 

--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -603,19 +603,19 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
       end
     end
 
-    context "with POINTER_SCROLL_FINGER remaps" do
-      let(:mapping) { {S: "POINTER_SCROLL_FINGER", D: "pointer_scroll_finger", F: "LEFTCTRL"} }
+    context "with POINTER_SCROLL remaps" do
+      let(:mapping) { {S: "POINTER_SCROLL", D: "pointer_scroll", F: "LEFTCTRL", G: "POINTER_SCROLL_FINGER"} }
 
       it "classifies them as combo remaps so simple remap does not rewrite the key" do
         simple, combo = remapper.send(:separate_mappings, mapping)
 
-        expect(simple).to eq({F: "LEFTCTRL"})
-        expect(combo).to eq({S: "POINTER_SCROLL_FINGER", D: "pointer_scroll_finger"})
+        expect(simple).to eq({F: "LEFTCTRL", G: "POINTER_SCROLL_FINGER"})
+        expect(combo).to eq({S: "POINTER_SCROLL", D: "pointer_scroll"})
       end
     end
   end
 
-  describe "POINTER_SCROLL_FINGER token handling" do
+  describe "POINTER_SCROLL token handling" do
     let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
     let(:remapper) do
       described_class.new(
@@ -630,15 +630,16 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
     let(:release_event) { Revdev::InputEvent.new(nil, Revdev::EV_KEY, Revdev::KEY_S, 0) }
 
     it "recognizes the token case-insensitively" do
-      expect(remapper.send(:pointer_scroll_finger_remap?, "POINTER_SCROLL_FINGER")).to be true
-      expect(remapper.send(:pointer_scroll_finger_remap?, :pointer_scroll_finger)).to be true
-      expect(remapper.send(:pointer_scroll_finger_remap?, "BTN_LEFT")).to be false
+      expect(remapper.send(:pointer_scroll_remap?, "POINTER_SCROLL")).to be true
+      expect(remapper.send(:pointer_scroll_remap?, :pointer_scroll)).to be true
+      expect(remapper.send(:pointer_scroll_remap?, "POINTER_SCROLL_FINGER")).to be false
+      expect(remapper.send(:pointer_scroll_remap?, "BTN_LEFT")).to be false
     end
 
     it "sends scroll on and swallows the token key press" do
       expect(scroll_channel).to receive(:send_scroll).with(true)
 
-      handled = remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+      handled = remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL")
 
       expect(handled).to be true
       expect(remapper.send(:scroll_pressed_codes)).to include(Revdev::KEY_S)
@@ -646,7 +647,7 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
 
     it "swallows repeat events while the token key is held" do
       allow(scroll_channel).to receive(:send_scroll)
-      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL")
 
       expect(remapper.send(:handle_pressed_pointer_scroll_key, repeat_event)).to be true
     end
@@ -655,7 +656,7 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
       expect(scroll_channel).to receive(:send_scroll).with(true).ordered
       expect(scroll_channel).to receive(:send_scroll).with(false).ordered
 
-      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL")
 
       expect(remapper.send(:handle_pressed_pointer_scroll_key, release_event)).to be true
       expect(remapper.send(:scroll_pressed_codes)).not_to include(Revdev::KEY_S)

--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -661,6 +661,63 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
       expect(remapper.send(:handle_pressed_pointer_scroll_key, release_event)).to be true
       expect(remapper.send(:scroll_pressed_codes)).not_to include(Revdev::KEY_S)
     end
+
+    it "passes through a token-mapped release when the scroll key was not pressed in scroll mode" do
+      allow(remapper).to receive(:uinput_keyboard).and_return(uinput_keyboard)
+      allow(uinput_keyboard).to receive(:write_input_event)
+      remapper.send(:get_or_record_key_code, Revdev::KEY_S, Revdev::KEY_S, 1)
+
+      expect(Fusuma::MultiLogger).not_to receive(:warn).with(/Invalid remapped value/)
+
+      handled = remapper.send(:handle_pointer_scroll_passthrough, release_event, "POINTER_SCROLL")
+
+      expect(handled).to be true
+      expect(uinput_keyboard).to have_received(:write_input_event) do |event|
+        expect(event.type).to eq(Revdev::EV_KEY)
+        expect(event.code).to eq(Revdev::KEY_S)
+        expect(event.value).to eq(0)
+      end
+    end
+
+    it "passes through a token-mapped repeat when the scroll key was not pressed in scroll mode" do
+      allow(remapper).to receive(:uinput_keyboard).and_return(uinput_keyboard)
+      allow(uinput_keyboard).to receive(:write_input_event)
+
+      expect(Fusuma::MultiLogger).not_to receive(:warn).with(/Invalid remapped value/)
+
+      handled = remapper.send(:handle_pointer_scroll_passthrough, repeat_event, "POINTER_SCROLL")
+
+      expect(handled).to be true
+      expect(uinput_keyboard).to have_received(:write_input_event) do |event|
+        expect(event.type).to eq(Revdev::EV_KEY)
+        expect(event.code).to eq(Revdev::KEY_S)
+        expect(event.value).to eq(2)
+      end
+    end
+
+    it "sends scroll off and clears pressed scroll keys when a keyboard is removed" do
+      keyboard_file = instance_double("IO")
+      source_keyboard = instance_double(
+        "Revdev::EventDevice",
+        file: keyboard_file,
+        read_input_event: nil
+      )
+      layer_reader = instance_double("IO")
+      allow(layer_manager).to receive(:reader).and_return(layer_reader)
+      allow(remapper).to receive(:create_virtual_keyboard)
+      allow(remapper).to receive(:reload_keyboards).and_return([source_keyboard])
+      allow(Fusuma::MultiLogger).to receive(:error)
+      expect(IO).to receive(:select).and_return([[keyboard_file]]).ordered
+      expect(IO).to receive(:select).and_raise(EOFError).ordered
+      allow(source_keyboard).to receive(:read_input_event).and_raise(Errno::ENODEV, "/dev/input/event1")
+      remapper.send(:scroll_pressed_codes).add(Revdev::KEY_S)
+
+      expect(scroll_channel).to receive(:send_scroll).with(false)
+
+      remapper.run
+
+      expect(remapper.send(:scroll_pressed_codes)).to be_empty
+    end
   end
 
   describe "key swap without double conversion" do

--- a/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/keyboard_remapper_spec.rb
@@ -602,6 +602,64 @@ RSpec.describe Fusuma::Plugin::Remap::KeyboardRemapper do
         expect(combo).to eq({})
       end
     end
+
+    context "with POINTER_SCROLL_FINGER remaps" do
+      let(:mapping) { {S: "POINTER_SCROLL_FINGER", D: "pointer_scroll_finger", F: "LEFTCTRL"} }
+
+      it "classifies them as combo remaps so simple remap does not rewrite the key" do
+        simple, combo = remapper.send(:separate_mappings, mapping)
+
+        expect(simple).to eq({F: "LEFTCTRL"})
+        expect(combo).to eq({S: "POINTER_SCROLL_FINGER", D: "pointer_scroll_finger"})
+      end
+    end
+  end
+
+  describe "POINTER_SCROLL_FINGER token handling" do
+    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel") }
+    let(:remapper) do
+      described_class.new(
+        layer_manager: layer_manager,
+        fusuma_writer: fusuma_writer,
+        config: config,
+        scroll_channel: scroll_channel
+      )
+    end
+    let(:press_event) { Revdev::InputEvent.new(nil, Revdev::EV_KEY, Revdev::KEY_S, 1) }
+    let(:repeat_event) { Revdev::InputEvent.new(nil, Revdev::EV_KEY, Revdev::KEY_S, 2) }
+    let(:release_event) { Revdev::InputEvent.new(nil, Revdev::EV_KEY, Revdev::KEY_S, 0) }
+
+    it "recognizes the token case-insensitively" do
+      expect(remapper.send(:pointer_scroll_finger_remap?, "POINTER_SCROLL_FINGER")).to be true
+      expect(remapper.send(:pointer_scroll_finger_remap?, :pointer_scroll_finger)).to be true
+      expect(remapper.send(:pointer_scroll_finger_remap?, "BTN_LEFT")).to be false
+    end
+
+    it "sends scroll on and swallows the token key press" do
+      expect(scroll_channel).to receive(:send_scroll).with(true)
+
+      handled = remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+
+      expect(handled).to be true
+      expect(remapper.send(:scroll_pressed_codes)).to include(Revdev::KEY_S)
+    end
+
+    it "swallows repeat events while the token key is held" do
+      allow(scroll_channel).to receive(:send_scroll)
+      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+
+      expect(remapper.send(:handle_pressed_pointer_scroll_key, repeat_event)).to be true
+    end
+
+    it "sends scroll off on release even if the current mapping changed" do
+      expect(scroll_channel).to receive(:send_scroll).with(true).ordered
+      expect(scroll_channel).to receive(:send_scroll).with(false).ordered
+
+      remapper.send(:handle_pointer_scroll_press, press_event, "POINTER_SCROLL_FINGER")
+
+      expect(remapper.send(:handle_pressed_pointer_scroll_key, release_event)).to be true
+      expect(remapper.send(:scroll_pressed_codes)).not_to include(Revdev::KEY_S)
+    end
   end
 
   describe "key swap without double conversion" do

--- a/spec/fusuma/plugin/remap/scroll_channel_spec.rb
+++ b/spec/fusuma/plugin/remap/scroll_channel_spec.rb
@@ -30,11 +30,25 @@ RSpec.describe Fusuma::Plugin::Remap::ScrollChannel do
       expect(channel.receive).to be false
     end
 
-    it "returns nil when the reader reaches EOF" do
+    it "returns :closed when the reader reaches EOF" do
       channel = build_channel
       channel.writer.close
 
-      expect(channel.receive).to be_nil
+      expect(channel.receive).to eq(:closed)
+    end
+
+    it "does not update the last state when non-blocking write raises EAGAIN" do
+      channel = build_channel
+      writer = instance_double("IO")
+      channel.instance_variable_set(:@writer, writer)
+
+      allow(writer).to receive(:write_nonblock).and_raise(Errno::EAGAIN)
+
+      channel.send_scroll(true)
+      channel.send_scroll(true)
+
+      expect(writer).to have_received(:write_nonblock).twice
+      expect(channel.instance_variable_get(:@last_scroll)).to be_nil
     end
 
     it "returns without blocking or raising when the pipe is full and unread" do

--- a/spec/fusuma/plugin/remap/scroll_channel_spec.rb
+++ b/spec/fusuma/plugin/remap/scroll_channel_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/scroll_channel"
+
+RSpec.describe Fusuma::Plugin::Remap::ScrollChannel do
+  def build_channel
+    described_class.__send__(:new)
+  end
+
+  describe "#send_scroll and #receive" do
+    it "sends true and false as JSON lines" do
+      channel = build_channel
+
+      channel.send_scroll(true)
+      channel.send_scroll(false)
+
+      expect(channel.receive).to be true
+      expect(channel.receive).to be false
+    end
+
+    it "deduplicates unchanged states" do
+      channel = build_channel
+
+      channel.send_scroll(true)
+      channel.send_scroll(true)
+      channel.send_scroll(false)
+
+      expect(channel.receive).to be true
+      expect(channel.receive).to be false
+    end
+
+    it "returns nil when the reader reaches EOF" do
+      channel = build_channel
+      channel.writer.close
+
+      expect(channel.receive).to be_nil
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/scroll_channel_spec.rb
+++ b/spec/fusuma/plugin/remap/scroll_channel_spec.rb
@@ -36,5 +36,25 @@ RSpec.describe Fusuma::Plugin::Remap::ScrollChannel do
 
       expect(channel.receive).to be_nil
     end
+
+    it "returns without blocking or raising when the pipe is full and unread" do
+      channel = build_channel
+      fill_pipe(channel.writer)
+
+      thread = Thread.new { channel.send_scroll(true) }
+
+      expect(thread.join(0.2)).to eq(thread)
+    ensure
+      thread&.kill
+      thread&.join
+    end
+  end
+
+  def fill_pipe(writer)
+    loop do
+      writer.write_nonblock("x" * 4096)
+    end
+  rescue IO::WaitWritable, Errno::EAGAIN
+    nil
   end
 end

--- a/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
@@ -5,7 +5,7 @@ require "fusuma/device"
 
 RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
   let(:fusuma_writer) { instance_double("IO", write: nil) }
-  let(:absinfo) { {absmin: 0, absmax: 1000, absfuzz: 0, absflat: 0, absresolution: 0} }
+  let(:absinfo) { {absmin: 0, absmax: 1000, absfuzz: 0, absflat: 0, resolution: 0} }
   let(:source_touchpad) do
     instance_double(
       "Revdev::EventDevice",
@@ -86,7 +86,7 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
     end
 
     context "with pointer scroll forwarding enabled" do
-      let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader")) }
+      let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader", closed?: false)) }
       let(:uinput_factory) { -> { double("UinputTouchpad", create_from_device: nil, destroy: nil, write_input_event: nil) } }
       let(:emulator_factory) { ->(device) { double("TwoFingerScrollEmulator", device: device) } }
 
@@ -126,7 +126,7 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
   end
 
   describe "pointer scroll forwarding helpers" do
-    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader"), receive: true) }
+    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader", closed?: false), receive: true) }
     let(:uinput) { double("UinputTouchpad", create_from_device: nil, destroy: nil, write_input_event: nil) }
     let(:emulator) { double("TwoFingerScrollEmulator") }
     let(:uinput_factory) { -> { uinput } }
@@ -195,6 +195,7 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
         uinput_factory: uinput_factory,
         emulator_factory: emulator_factory
       )
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
 
       remapper.send(:read_scroll_channel)
 
@@ -356,31 +357,33 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
       described_class.new(
         fusuma_writer: fusuma_writer,
         source_touchpads: source_touchpads,
-        touchpad_name_patterns: ["Touchpad"]
+        touchpad_name_patterns: ["Touchpad"],
+        uinput_factory: -> { uinput }
       )
     end
 
     before do
-      allow(remapper).to receive(:uinput).and_return(uinput)
       allow(Fusuma::Device).to receive(:reset)
       allow(Fusuma::Device).to receive(:all).and_return([new_device])
       allow(Revdev::EventDevice).to receive(:new).and_return(new_touchpad)
     end
 
     it "destroys existing uinput" do
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
       expect(uinput).to receive(:destroy)
       remapper.send(:reload_touchpads)
     end
 
     it "handles IOError when destroying uinput (already destroyed)" do
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
       allow(uinput).to receive(:destroy).and_raise(IOError)
       expect { remapper.send(:reload_touchpads) }.not_to raise_error
     end
 
-    it "resets @uinput to nil" do
-      remapper.instance_variable_set(:@uinput, uinput)
+    it "rebuilds virtual touchpads keyed by the reconnected devices" do
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
       remapper.send(:reload_touchpads)
-      expect(remapper.instance_variable_get(:@uinput)).to be_nil
+      expect(remapper.instance_variable_get(:@uinputs_by_touchpad).keys).to eq([new_touchpad])
     end
 
     it "calls Fusuma::Device.reset to refresh device cache" do
@@ -400,7 +403,8 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
         described_class.new(
           fusuma_writer: fusuma_writer,
           source_touchpads: source_touchpads,
-          touchpad_name_patterns: nil
+          touchpad_name_patterns: nil,
+          uinput_factory: -> { uinput }
         )
       end
 

--- a/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
     )
   end
   let(:source_touchpads) { [source_touchpad] }
+  let(:input_event) { Revdev::InputEvent.new(nil, Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 100) }
 
   describe "#initialize" do
     context "without touchpad_name_patterns" do
@@ -73,6 +74,129 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
         source_touchpads: source_touchpads
       )
       expect(remapper.instance_variable_get(:@palm_detectors).keys).to eq(source_touchpads)
+    end
+
+    it "does not grab touchpads by default" do
+      expect(source_touchpad).not_to receive(:grab)
+
+      described_class.new(
+        fusuma_writer: fusuma_writer,
+        source_touchpads: source_touchpads
+      )
+    end
+
+    context "with pointer scroll forwarding enabled" do
+      let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader")) }
+      let(:uinput_factory) { -> { double("UinputTouchpad", create_from_device: nil, destroy: nil, write_input_event: nil) } }
+      let(:emulator_factory) { ->(device) { double("TwoFingerScrollEmulator", device: device) } }
+
+      before do
+        allow(source_touchpad).to receive(:grab)
+      end
+
+      it "grabs source touchpads" do
+        expect(source_touchpad).to receive(:grab)
+
+        described_class.new(
+          fusuma_writer: fusuma_writer,
+          source_touchpads: source_touchpads,
+          pointer_scroll_enabled: true,
+          scroll_channel: scroll_channel,
+          uinput_factory: uinput_factory,
+          emulator_factory: emulator_factory
+        )
+      end
+
+      it "falls back to disabled forwarding when grab fails" do
+        allow(source_touchpad).to receive(:grab).and_raise(Errno::EBUSY)
+        expect(Fusuma::MultiLogger).to receive(:warn).with(/Failed to grab touchpad/)
+
+        remapper = described_class.new(
+          fusuma_writer: fusuma_writer,
+          source_touchpads: source_touchpads,
+          pointer_scroll_enabled: true,
+          scroll_channel: scroll_channel,
+          uinput_factory: uinput_factory,
+          emulator_factory: emulator_factory
+        )
+
+        expect(remapper.send(:pointer_scroll_enabled?)).to be false
+      end
+    end
+  end
+
+  describe "pointer scroll forwarding helpers" do
+    let(:scroll_channel) { instance_double("Fusuma::Plugin::Remap::ScrollChannel", reader: double("reader"), receive: true) }
+    let(:uinput) { double("UinputTouchpad", create_from_device: nil, destroy: nil, write_input_event: nil) }
+    let(:emulator) { double("TwoFingerScrollEmulator") }
+    let(:uinput_factory) { -> { uinput } }
+    let(:emulator_factory) { ->(_device) { emulator } }
+
+    before do
+      allow(source_touchpad).to receive(:grab)
+    end
+
+    it "creates one virtual touchpad per source when forwarding is enabled" do
+      second_touchpad = instance_double(
+        "Revdev::EventDevice",
+        file: instance_double("File"),
+        absinfo_for_axis: absinfo
+      )
+      allow(second_touchpad).to receive(:grab)
+      uinput1 = double("UinputTouchpad1", create_from_device: nil)
+      uinput2 = double("UinputTouchpad2", create_from_device: nil)
+      factory_calls = [uinput1, uinput2]
+      remapper = described_class.new(
+        fusuma_writer: fusuma_writer,
+        source_touchpads: [source_touchpad, second_touchpad],
+        pointer_scroll_enabled: true,
+        scroll_channel: scroll_channel,
+        uinput_factory: -> { factory_calls.shift },
+        emulator_factory: emulator_factory
+      )
+
+      remapper.send(:create_virtual_touchpad)
+
+      expect(uinput1).to have_received(:create_from_device).with(name: described_class::VIRTUAL_TOUCHPAD_NAME, device: source_touchpad)
+      expect(uinput2).to have_received(:create_from_device).with(name: described_class::VIRTUAL_TOUCHPAD_NAME, device: second_touchpad)
+    end
+
+    it "applies scroll channel values to all emulators and writes returned events" do
+      release_event = Revdev::InputEvent.new(nil, Revdev::EV_SYN, Revdev::SYN_REPORT, 0)
+      allow(emulator).to receive(:set_scroll_mode).with(true).and_return([release_event])
+      remapper = described_class.new(
+        fusuma_writer: fusuma_writer,
+        source_touchpads: source_touchpads,
+        pointer_scroll_enabled: true,
+        scroll_channel: scroll_channel,
+        uinput_factory: uinput_factory,
+        emulator_factory: emulator_factory
+      )
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
+      remapper.instance_variable_set(:@emulators_by_touchpad, {source_touchpad => emulator})
+
+      remapper.send(:read_scroll_channel)
+
+      expect(uinput).to have_received(:write_input_event).with(release_event)
+    end
+
+    it "forwards physical events through the emulator only when enabled" do
+      forwarded_event = Revdev::InputEvent.new(nil, Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 200)
+      allow(emulator).to receive(:process).with(input_event).and_return([forwarded_event])
+      remapper = described_class.new(
+        fusuma_writer: fusuma_writer,
+        source_touchpads: source_touchpads,
+        pointer_scroll_enabled: true,
+        scroll_channel: scroll_channel,
+        uinput_factory: uinput_factory,
+        emulator_factory: emulator_factory
+      )
+      remapper.instance_variable_set(:@uinputs_by_touchpad, {source_touchpad => uinput})
+      remapper.instance_variable_set(:@emulators_by_touchpad, {source_touchpad => emulator})
+
+      remapper.send(:forward_touchpad_event, source_touchpad, input_event)
+
+      expect(uinput).to have_received(:write_input_event).with(forwarded_event)
     end
   end
 
@@ -269,9 +393,9 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
             [new_device]
           end
         end
-        allow(remapper).to receive(:sleep)
+        allow_any_instance_of(Fusuma::Plugin::Remap::DeviceSelector).to receive(:sleep)
 
-        expect(remapper).to receive(:sleep).with(3).exactly(2).times
+        expect_any_instance_of(Fusuma::Plugin::Remap::DeviceSelector).to receive(:sleep).with(3).exactly(2).times
         remapper.send(:reload_touchpads)
       end
     end
@@ -288,6 +412,7 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
     end
 
     it "logs reconnection info" do
+      allow(Fusuma::MultiLogger).to receive(:info)
       expect(Fusuma::MultiLogger).to receive(:info).with(/Touchpad reconnected/)
       remapper.send(:reload_touchpads)
     end

--- a/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
+++ b/spec/fusuma/plugin/remap/touchpad_remapper_spec.rb
@@ -180,6 +180,34 @@ RSpec.describe Fusuma::Plugin::Remap::TouchpadRemapper do
       expect(uinput).to have_received(:write_input_event).with(release_event)
     end
 
+    it "handles scroll channel EOF by releasing scroll and continuing forwarding" do
+      channel = Fusuma::Plugin::Remap::ScrollChannel.__send__(:new)
+      channel.writer.close
+      release_event = Revdev::InputEvent.new(nil, Revdev::EV_SYN, Revdev::SYN_REPORT, 0)
+      forwarded_event = Revdev::InputEvent.new(nil, Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 200)
+      allow(emulator).to receive(:set_scroll_mode).with(false).and_return([release_event])
+      allow(emulator).to receive(:process).with(input_event).and_return([forwarded_event])
+      remapper = described_class.new(
+        fusuma_writer: fusuma_writer,
+        source_touchpads: source_touchpads,
+        pointer_scroll_enabled: true,
+        scroll_channel: channel,
+        uinput_factory: uinput_factory,
+        emulator_factory: emulator_factory
+      )
+
+      remapper.send(:read_scroll_channel)
+
+      expect(channel.reader).to be_closed
+      expect(remapper.send(:selectable_ios)).not_to include(channel.reader)
+      expect(uinput).to have_received(:write_input_event).with(release_event)
+      expect(remapper.send(:pointer_scroll_enabled?)).to be true
+
+      remapper.send(:forward_touchpad_event, source_touchpad, input_event)
+
+      expect(uinput).to have_received(:write_input_event).with(forwarded_event)
+    end
+
     it "forwards physical events through the emulator only when enabled" do
       forwarded_event = Revdev::InputEvent.new(nil, Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 200)
       allow(emulator).to receive(:process).with(input_event).and_return([forwarded_event])

--- a/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
+++ b/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
@@ -38,22 +38,32 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
     events.map { |input_event| [input_event.type, input_event.code, input_event.value] }
   end
 
-  def touch_begin
+  def touch_begin(x: 400, y: 500, tracking_id: 10, slot: 0)
     process_frame(
-      abs(Revdev::ABS_MT_SLOT, 0),
-      abs(Revdev::ABS_MT_TRACKING_ID, 10),
-      abs(Revdev::ABS_MT_POSITION_X, 400),
-      abs(Revdev::ABS_MT_POSITION_Y, 500),
+      abs(Revdev::ABS_MT_SLOT, slot),
+      abs(Revdev::ABS_MT_TRACKING_ID, tracking_id),
+      abs(Revdev::ABS_MT_POSITION_X, x),
+      abs(Revdev::ABS_MT_POSITION_Y, y),
       key(Revdev::BTN_TOUCH, 1),
       key(Revdev::BTN_TOOL_FINGER, 1),
       syn
     )
   end
 
-  def first_scroll_motion
+  def touch_end(slot: 0)
     process_frame(
-      abs(Revdev::ABS_MT_POSITION_X, 450),
-      abs(Revdev::ABS_MT_POSITION_Y, 520),
+      abs(Revdev::ABS_MT_SLOT, slot),
+      abs(Revdev::ABS_MT_TRACKING_ID, -1),
+      key(Revdev::BTN_TOUCH, 0),
+      key(Revdev::BTN_TOOL_FINGER, 0),
+      syn
+    )
+  end
+
+  def first_scroll_motion(x: 450, y: 520)
+    process_frame(
+      abs(Revdev::ABS_MT_POSITION_X, x),
+      abs(Revdev::ABS_MT_POSITION_Y, y),
       syn
     )
   end
@@ -151,19 +161,32 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
       expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
     end
 
-    it "clears the scroll session on touch end while the key remains pressed" do
+    it "keeps scroll mode across touch restarts while the key remains pressed" do
       emulator.set_scroll_mode(true)
       touch_begin
       first_scroll_motion
 
-      process_frame(
-        abs(Revdev::ABS_MT_TRACKING_ID, -1),
-        key(Revdev::BTN_TOUCH, 0),
-        key(Revdev::BTN_TOOL_FINGER, 0),
-        syn
-      )
+      touch_end
 
+      begin_output = touch_begin(x: 100, y: 200, tracking_id: 20)
+
+      expect(tuples(begin_output)).not_to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(begin_output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+
+      motion_output = first_scroll_motion(x: 130, y: 220)
+
+      expect(tuples(motion_output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(motion_output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+
+    it "does not restart scrolling after scroll mode is disabled" do
+      emulator.set_scroll_mode(true)
       touch_begin
+      first_scroll_motion
+      touch_end
+
+      emulator.set_scroll_mode(false)
+      touch_begin(x: 100, y: 200, tracking_id: 20)
       output = first_scroll_motion
 
       expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])

--- a/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
+++ b/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/two_finger_scroll_emulator"
+
+RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
+  let(:device) { double("Revdev::EventDevice") }
+  let(:emulator) { described_class.new(device: device) }
+  let(:synthetic_slot) { 4 }
+
+  before do
+    allow(device).to receive(:absinfo_for_axis).with(Revdev::ABS_MT_SLOT).and_return(absmin: 0, absmax: 4)
+    allow(device).to receive(:absinfo_for_axis).with(Revdev::ABS_MT_POSITION_X).and_return(absmin: 0, absmax: 1000)
+    allow(device).to receive(:absinfo_for_axis).with(Revdev::ABS_MT_POSITION_Y).and_return(absmin: 0, absmax: 1000)
+  end
+
+  def event(type, code, value)
+    Revdev::InputEvent.new(nil, type, code, value)
+  end
+
+  def abs(code, value)
+    event(Revdev::EV_ABS, code, value)
+  end
+
+  def key(code, value)
+    event(Revdev::EV_KEY, code, value)
+  end
+
+  def syn
+    event(Revdev::EV_SYN, Revdev::SYN_REPORT, 0)
+  end
+
+  def process_frame(*events)
+    events.flat_map { |input_event| emulator.process(input_event) }
+  end
+
+  def tuples(events)
+    events.map { |input_event| [input_event.type, input_event.code, input_event.value] }
+  end
+
+  def touch_begin
+    process_frame(
+      abs(Revdev::ABS_MT_SLOT, 0),
+      abs(Revdev::ABS_MT_TRACKING_ID, 10),
+      abs(Revdev::ABS_MT_POSITION_X, 400),
+      abs(Revdev::ABS_MT_POSITION_Y, 500),
+      key(Revdev::BTN_TOUCH, 1),
+      key(Revdev::BTN_TOOL_FINGER, 1),
+      syn
+    )
+  end
+
+  def first_scroll_motion
+    process_frame(
+      abs(Revdev::ABS_MT_POSITION_X, 450),
+      abs(Revdev::ABS_MT_POSITION_Y, 520),
+      syn
+    )
+  end
+
+  describe "#process" do
+    it "passes events through immediately when scroll mode is off" do
+      input_event = abs(Revdev::ABS_MT_POSITION_X, 100)
+
+      expect(emulator.process(input_event)).to eq([input_event])
+    end
+
+    it "does not inject a synthetic finger until the real finger moves" do
+      emulator.set_scroll_mode(true)
+
+      output = touch_begin
+
+      expect(tuples(output)).not_to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+
+    it "injects the synthetic finger in the first motion frame and restores the real slot" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+
+      output = first_scroll_motion
+
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 600])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 520])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_FINGER, 0])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+      expect(tuples(output)[-2]).to eq([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, 0])
+      expect(tuples(output).last).to eq([Revdev::EV_SYN, Revdev::SYN_REPORT, 0])
+    end
+
+    it "mirrors subsequent real finger movement to the synthetic slot" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      output = process_frame(
+        abs(Revdev::ABS_MT_POSITION_X, 500),
+        abs(Revdev::ABS_MT_POSITION_Y, 530),
+        syn
+      )
+
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 650])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 530])
+      synthetic_tracking_ids = output.select { |input_event|
+        input_event.type == Revdev::EV_ABS &&
+          input_event.code == Revdev::ABS_MT_TRACKING_ID &&
+          input_event.value != -1
+      }
+      expect(synthetic_tracking_ids).to be_empty
+    end
+
+    it "releases the synthetic finger when a second real finger appears" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      output = process_frame(
+        abs(Revdev::ABS_MT_SLOT, 1),
+        abs(Revdev::ABS_MT_TRACKING_ID, 11),
+        abs(Revdev::ABS_MT_POSITION_X, 200),
+        abs(Revdev::ABS_MT_POSITION_Y, 300),
+        key(Revdev::BTN_TOOL_FINGER, 0),
+        key(Revdev::BTN_TOOL_DOUBLETAP, 1),
+        syn
+      )
+
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_TRACKING_ID, -1])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+
+    it "releases the synthetic finger when a later real finger uses the synthetic slot" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      output = process_frame(
+        abs(Revdev::ABS_MT_SLOT, synthetic_slot),
+        abs(Revdev::ABS_MT_TRACKING_ID, 11),
+        abs(Revdev::ABS_MT_POSITION_X, 200),
+        abs(Revdev::ABS_MT_POSITION_Y, 300),
+        key(Revdev::BTN_TOOL_FINGER, 0),
+        key(Revdev::BTN_TOOL_DOUBLETAP, 1),
+        syn
+      )
+
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_TRACKING_ID, -1])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+
+    it "clears the scroll session on touch end while the key remains pressed" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      process_frame(
+        abs(Revdev::ABS_MT_TRACKING_ID, -1),
+        key(Revdev::BTN_TOUCH, 0),
+        key(Revdev::BTN_TOOL_FINGER, 0),
+        syn
+      )
+
+      touch_begin
+      output = first_scroll_motion
+
+      expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+  end
+
+  describe "#set_scroll_mode" do
+    it "does nothing for a key press and release with no touch motion" do
+      expect(emulator.set_scroll_mode(true)).to eq([])
+      expect(emulator.set_scroll_mode(false)).to eq([])
+    end
+
+    it "returns a release frame when scroll mode is disabled during an active synthetic touch" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      output = emulator.set_scroll_mode(false)
+
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_TRACKING_ID, -1])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 0])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_FINGER, 1])
+      expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOUCH, 1])
+      expect(tuples(output).last).to eq([Revdev::EV_SYN, Revdev::SYN_REPORT, 0])
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
+++ b/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
@@ -38,6 +38,17 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
     events.map { |input_event| [input_event.type, input_event.code, input_event.value] }
   end
 
+  def tracking_ids_by_slot(events)
+    current_slot = 0
+    events.each_with_object(Hash.new { |hash, slot| hash[slot] = [] }) do |input_event, tracking_ids|
+      if input_event.type == Revdev::EV_ABS && input_event.code == Revdev::ABS_MT_SLOT
+        current_slot = input_event.value
+      elsif input_event.type == Revdev::EV_ABS && input_event.code == Revdev::ABS_MT_TRACKING_ID
+        tracking_ids[current_slot] << input_event.value
+      end
+    end
+  end
+
   def touch_begin(x: 400, y: 500, tracking_id: 10, slot: 0)
     process_frame(
       abs(Revdev::ABS_MT_SLOT, slot),
@@ -99,6 +110,35 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
       expect(tuples(output).last).to eq([Revdev::EV_SYN, Revdev::SYN_REPORT, 0])
     end
 
+    it "keeps slot coordinates across touch restarts and ignores begin-frame motion" do
+      emulator.set_scroll_mode(true)
+      touch_begin(x: 450, y: 500)
+      first_scroll_motion(x: 450, y: 520)
+      touch_end
+
+      begin_output = process_frame(
+        abs(Revdev::ABS_MT_SLOT, 0),
+        abs(Revdev::ABS_MT_TRACKING_ID, 20),
+        abs(Revdev::ABS_MT_POSITION_Y, 700),
+        key(Revdev::BTN_TOUCH, 1),
+        key(Revdev::BTN_TOOL_FINGER, 1),
+        syn
+      )
+
+      expect(tuples(begin_output)).not_to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(begin_output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+
+      motion_output = process_frame(
+        abs(Revdev::ABS_MT_POSITION_Y, 720),
+        syn
+      )
+
+      expect(tuples(motion_output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(motion_output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 600])
+      expect(tuples(motion_output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 720])
+      expect(tuples(motion_output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+    end
+
     context "when the device has no free multitouch slot" do
       before do
         allow(device).to receive(:absinfo_for_axis).with(Revdev::ABS_MT_SLOT).and_return(absmin: 0, absmax: 0)
@@ -118,6 +158,27 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
         expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
         expect(output.map(&:value)).not_to include(nil)
       end
+    end
+
+    it "passes motion through when the real slot has incomplete coordinates" do
+      emulator.set_scroll_mode(true)
+      process_frame(
+        abs(Revdev::ABS_MT_SLOT, 0),
+        abs(Revdev::ABS_MT_TRACKING_ID, 10),
+        abs(Revdev::ABS_MT_POSITION_X, 450),
+        syn
+      )
+
+      output = process_frame(
+        abs(Revdev::ABS_MT_POSITION_X, 460),
+        syn
+      )
+
+      expect(tuples(output)).to eq([
+        [Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 460],
+        [Revdev::EV_SYN, Revdev::SYN_REPORT, 0]
+      ])
+      expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
     end
 
     it "mirrors subsequent real finger movement to the synthetic slot" do
@@ -178,7 +239,8 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
       )
 
       expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
-      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_TRACKING_ID, -1])
+      expect(tracking_ids_by_slot(output)[synthetic_slot]).to include(11)
+      expect(tracking_ids_by_slot(output)[synthetic_slot]).not_to include(-1)
       expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
     end
 
@@ -233,6 +295,36 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
       expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOOL_FINGER, 1])
       expect(tuples(output)).to include([Revdev::EV_KEY, Revdev::BTN_TOUCH, 1])
       expect(tuples(output).last).to eq([Revdev::EV_SYN, Revdev::SYN_REPORT, 0])
+    end
+
+    it "flushes a buffered partial frame before disabling scroll mode" do
+      emulator.set_scroll_mode(true)
+      touch_begin
+      first_scroll_motion
+
+      buffered_events = [
+        abs(Revdev::ABS_MT_SLOT, 0),
+        abs(Revdev::ABS_MT_TRACKING_ID, -1)
+      ]
+      buffered_events.each { |input_event| expect(emulator.process(input_event)).to eq([]) }
+
+      output = emulator.set_scroll_mode(false)
+
+      expect(tuples(output).first(2)).to eq(tuples(buffered_events))
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_SLOT, synthetic_slot])
+      expect(tuples(output)).to include([Revdev::EV_ABS, Revdev::ABS_MT_TRACKING_ID, -1])
+
+      remaining_output = process_frame(
+        key(Revdev::BTN_TOUCH, 0),
+        key(Revdev::BTN_TOOL_FINGER, 0),
+        syn
+      )
+
+      expect(tuples(remaining_output)).to eq([
+        [Revdev::EV_KEY, Revdev::BTN_TOUCH, 0],
+        [Revdev::EV_KEY, Revdev::BTN_TOOL_FINGER, 0],
+        [Revdev::EV_SYN, Revdev::SYN_REPORT, 0]
+      ])
     end
   end
 end

--- a/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
+++ b/spec/fusuma/plugin/remap/two_finger_scroll_emulator_spec.rb
@@ -99,6 +99,27 @@ RSpec.describe Fusuma::Plugin::Remap::TwoFingerScrollEmulator do
       expect(tuples(output).last).to eq([Revdev::EV_SYN, Revdev::SYN_REPORT, 0])
     end
 
+    context "when the device has no free multitouch slot" do
+      before do
+        allow(device).to receive(:absinfo_for_axis).with(Revdev::ABS_MT_SLOT).and_return(absmin: 0, absmax: 0)
+      end
+
+      it "passes motion through without injecting nil-valued synthetic events" do
+        emulator.set_scroll_mode(true)
+        touch_begin
+
+        output = first_scroll_motion
+
+        expect(tuples(output)).to eq([
+          [Revdev::EV_ABS, Revdev::ABS_MT_POSITION_X, 450],
+          [Revdev::EV_ABS, Revdev::ABS_MT_POSITION_Y, 520],
+          [Revdev::EV_SYN, Revdev::SYN_REPORT, 0]
+        ])
+        expect(tuples(output)).not_to include([Revdev::EV_KEY, Revdev::BTN_TOOL_DOUBLETAP, 1])
+        expect(output.map(&:value)).not_to include(nil)
+      end
+    end
+
     it "mirrors subsequent real finger movement to the synthetic slot" do
       emulator.set_scroll_mode(true)
       touch_begin

--- a/spec/fusuma/plugin/remap/uinput_touchpad_spec.rb
+++ b/spec/fusuma/plugin/remap/uinput_touchpad_spec.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "fusuma/plugin/remap/uinput_touchpad"
+
+RSpec.describe UinputTouchpad do
+  let(:file) { double("uinput file", syswrite: nil) }
+  let(:ioctls) { [] }
+  let(:uinput) do
+    described_class.allocate.tap do |device|
+      device.instance_variable_set(:@file, file)
+      device.instance_variable_set(:@is_created, false)
+    end
+  end
+  let(:device_id) { double("InputId", vendor: 0x1234, product: 0x5678, version: 1) }
+  let(:source_device) { double("Revdev::EventDevice", device_id: device_id) }
+  let(:absinfo) { {absmin: 0, absmax: 1000, absfuzz: 0, absflat: 0, resolution: 1} }
+
+  before do
+    allow(file).to receive(:ioctl) do |request, argument|
+      ioctls << [request, argument]
+      0
+    end
+    allow(source_device).to receive(:absinfo_for_axis).and_return(absinfo)
+    allow(source_device).to receive(:read_ioctl_with) do |request|
+      case request & 0xff
+      when 0x20
+        bit_string([Revdev::EV_KEY, Revdev::EV_ABS, Revdev::EV_REL, Revdev::EV_MSC], Revdev::EV_CNT)
+      when 0x20 + Revdev::EV_KEY
+        bit_string([Revdev::BTN_LEFT, Revdev::BTN_TOUCH, Revdev::BTN_TOOL_FINGER], Revdev::KEY_CNT)
+      when 0x20 + Revdev::EV_ABS
+        bit_string([
+          Revdev::ABS_X,
+          Revdev::ABS_Y,
+          Revdev::ABS_MT_SLOT,
+          Revdev::ABS_MT_POSITION_X,
+          Revdev::ABS_MT_POSITION_Y,
+          Revdev::ABS_MT_TRACKING_ID,
+          Revdev::ABS_MT_PRESSURE
+        ], Revdev::ABS_CNT)
+      when 0x20 + Revdev::EV_REL
+        bit_string([Revdev::REL_X], Revdev::REL_CNT)
+      when 0x20 + Revdev::EV_MSC
+        bit_string([0x05], Revdev::MSC_CNT)
+      when 0x09
+        bit_string([Revdev::INPUT_PROP_POINTER, Revdev::INPUT_PROP_BUTTONPAD], Revdev::INPUT_PROP_CNT)
+      else
+        "".b
+      end
+    end
+  end
+
+  def bit_string(bits, max)
+    bytes = Array.new((max + 7) / 8, 0)
+    bits.each { |bit| bytes[bit / 8] |= (1 << (bit % 8)) }
+    bytes.pack("C*")
+  end
+
+  describe "#create_from_device" do
+    it "sets only key bits supported by the source device" do
+      uinput.create_from_device(name: "fusuma_virtual_touchpad", device: source_device)
+
+      expect(ioctls).to include([Ruinput::UI_SET_KEYBIT, Revdev::BTN_LEFT])
+      expect(ioctls).to include([Ruinput::UI_SET_KEYBIT, Revdev::BTN_TOUCH])
+      expect(ioctls).not_to include([Ruinput::UI_SET_KEYBIT, Revdev::BTN_RIGHT])
+    end
+
+    it "sets all supported absolute axes including pressure-like axes" do
+      uinput.create_from_device(name: "fusuma_virtual_touchpad", device: source_device)
+
+      expect(ioctls).to include([Ruinput::UI_SET_ABSBIT, Revdev::ABS_MT_POSITION_X])
+      expect(ioctls).to include([Ruinput::UI_SET_ABSBIT, Revdev::ABS_MT_PRESSURE])
+    end
+
+    it "copies relative, MSC, and input property bits from the source device" do
+      uinput.create_from_device(name: "fusuma_virtual_touchpad", device: source_device)
+
+      expect(ioctls).to include([Ruinput::UI_SET_RELBIT, Revdev::REL_X])
+      expect(ioctls).to include([Ruinput::UI_SET_MSCBIT, 0x05])
+      expect(ioctls).to include([Ruinput::UI_SET_PROPBIT, Revdev::INPUT_PROP_POINTER])
+      expect(ioctls).to include([Ruinput::UI_SET_PROPBIT, Revdev::INPUT_PROP_BUTTONPAD])
+    end
+  end
+end

--- a/spec/fusuma/plugin/remap/uinput_touchpad_spec.rb
+++ b/spec/fusuma/plugin/remap/uinput_touchpad_spec.rb
@@ -80,5 +80,21 @@ RSpec.describe UinputTouchpad do
       expect(ioctls).to include([Ruinput::UI_SET_PROPBIT, Revdev::INPUT_PROP_POINTER])
       expect(ioctls).to include([Ruinput::UI_SET_PROPBIT, Revdev::INPUT_PROP_BUTTONPAD])
     end
+
+    it "falls back to static event setup when capability probing returns no events" do
+      allow(uinput).to receive(:supported_capabilities).and_return(
+        events: [],
+        keys: [],
+        abs: [],
+        rels: [],
+        mscs: [],
+        props: []
+      )
+
+      expect(Fusuma::MultiLogger).to receive(:warn).with(/Failed to probe touchpad capabilities/)
+      expect(uinput).to receive(:set_all_events)
+
+      uinput.create_from_device(name: "fusuma_virtual_touchpad", device: source_device)
+    end
   end
 end


### PR DESCRIPTION
## Summary

Implements the `remap: { S: POINTER_SCROLL }` syntax: while a remapped key is held in thumbsense context, one-finger touchpad motion becomes native finger scrolling instead of pointer movement. The key press is swallowed, so it does not type the original character.

(The token was originally proposed as `POINTER_SCROLL_FINGER` in the fusuma-plugin-thumbsense README TODO; it was renamed to `POINTER_SCROLL` to express the user-facing behavior and hide the implementation detail.)

```yaml
---
context:
  thumbsense: true

remap:
  S: POINTER_SCROLL
```

## How it works

- **Native scroll via two-finger emulation**: the touchpad remapper injects a synthetic second finger on a virtual touchpad, so libinput itself generates native `POINTER_SCROLL_FINGER` scroll events. Natural scroll, scroll speed, and kinetic scrolling follow the desktop settings; no extra sensitivity config is introduced.
- **`ScrollChannel`** (new): a `LayerManager`-style singleton pipe created before fork. The keyboard remapper fork notifies the touchpad remapper fork of scroll on/off. Writes are non-blocking (`write_nonblock`) so a missing reader can never stall the keyboard loop.
- **KeyboardRemapper**: treats the mapping value `POINTER_SCROLL` as a special token (case-insensitive). Press sends scroll-on, release sends scroll-off, and press/release/repeat are all swallowed. Release stays consistent even if the layer changes while the key is held.
- **TouchpadRemapper**: only when the token exists somewhere in the config, physical touchpads are grabbed and all events are forwarded to per-source virtual touchpads. Without the token, behavior is completely unchanged (no grab, no forwarding). On `EBUSY` the grab falls back to the previous non-forwarding behavior.
- **TwoFingerScrollEmulator** (new): a pure state machine over the ABS_MT protocol. The synthetic finger is injected lazily on the first motion frame (a plain key tap without motion injects nothing, avoiding accidental two-finger taps), mirrors the real finger with an X offset, and is released on key release, on a second real finger, or on touch end. Scroll mode itself persists while the key is held: lifting the finger and touching again resumes scrolling on the next movement, matching how button remaps (e.g. `J: BTN_LEFT`) stay held across touch restarts.
- **UinputTouchpad**: `create_from_device` now clones the source device faithfully (EV_KEY/EV_ABS/EV_REL/EV_MSC bits, absinfo for all axes, and `INPUT_PROP_*` bits such as `BUTTONPAD`/`POINTER` via `UI_SET_PROPBIT`), so libinput treats the virtual touchpad like the physical one.
- **DeviceSelector**: excludes `fusuma_virtual_touchpad` / `fusuma_virtual_keyboard` from device selection, fixing a latent feedback loop where the default `touchpad` pattern could re-select our own virtual device after reconnection.

## Verification

- `bundle exec rspec`: 244 examples, 0 failures
- `bundle exec standardrb`: pass
- Reviewed with adversarial passes (Copilot review + a multi-agent high-effort review): confirmed findings were fixed in d1426e2, 2619189, 9b1f376, 79aedd3, 6d1d499, 29a4ffe, b5a1edd and 1ab03e3, followed by a cleanup pass (cbc0fd4).
- Confirmed on real hardware: touch + key hold scrolls without moving the pointer, and scrolling continues across touch restarts while the key is held (ac590e7).

## Unverified (needs testing on real hardware)

- [x] libinput actually interprets the synthetic two-finger touch as finger scrolling (confirmed on a real laptop)
- [x] Natural scroll / scroll speed / kinetic scrolling follow desktop settings on the virtual touchpad
- [ ] No regression in palm/thumb detection and disable-while-typing while forwarding is active
- [ ] uinput/grab permissions, `EBUSY` fallback, and touchpad reconnection behave correctly on real devices
- [ ] Multiple touchpads and devices with few MT slots work as expected

## Manual testing steps

1. Install this branch together with fusuma-plugin-thumbsense, and add to `~/.config/fusuma/config.yml`:
   ```yaml
   ---
   context:
     thumbsense: true

   remap:
     S: POINTER_SCROLL
   ```
2. Start fusuma, touch the touchpad, hold <kbd>S</kbd>, and move one finger: the page should scroll and the pointer should not move.
3. While still holding <kbd>S</kbd>, lift the finger and touch again, then move: scrolling should continue.
4. Release <kbd>S</kbd>: normal pointer movement should resume immediately.
5. Tap <kbd>S</kbd> while touching without moving: nothing should happen (no character, no right-click / two-finger tap misfire).
6. Put a second real finger down during scrolling: the synthetic finger should be released and normal multi-touch should resume.
7. Confirm existing thumbsense remaps (e.g. `J: BTN_LEFT`) and configs without `POINTER_SCROLL` behave exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
